### PR TITLE
Set Fee Recipient Callable Anytime + Optionally in Prepare Blueprint

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -234,13 +234,14 @@ contract BlueprintV12 is
         blueprints[_blueprintID].saleState = SaleState.not_started;
         //assign the erc721 token index to the blueprint
         blueprints[_blueprintID].erc721TokenIndex = latestErc721TokenIndex;
-        latestErc721TokenIndex += blueprints[_blueprintID].capacity;
+        uint64 _capacity = blueprints[_blueprintID].capacity;
+        latestErc721TokenIndex += _capacity;
         blueprintIndex++;
 
         emit BlueprintPrepared(
             _blueprintID,
             blueprints[_blueprintID].artist,
-            blueprints[_blueprintID].capacity,
+            _capacity,
             _blueprintMetaData,
             blueprints[_blueprintID].baseTokenUri
         );

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,6 +5,7 @@ require("@nomiclabs/hardhat-etherscan");
 require("hardhat-deploy");
 require("@nomiclabs/hardhat-ethers");
 require("@openzeppelin/hardhat-upgrades");
+require('hardhat-contract-sizer');
 
 const {
   rinkebyPrivateKey,
@@ -19,7 +20,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 200,
+        runs: 1,
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.7",
     "hardhat": "^2.4.1",
+    "hardhat-contract-sizer": "^2.6.1",
     "hardhat-gas-reporter": "^1.0.4",
     "keccak256": "^1.0.3",
     "merkletreejs": "^0.2.24",

--- a/test/ERC20-tests.js
+++ b/test/ERC20-tests.js
@@ -15,6 +15,12 @@ const tenThousandPieces = 10000;
 const oneThousandPieces = 1000;
 const zero = BigNumber.from(0).toString();
 const fiveHundredPieces = BigNumber.from(oneThousandPieces).div(2);
+const emptyFeeRecipients = {
+  primaryFeeBPS: [],
+  secondaryFeeBPS: [],
+  primaryFeeRecipients: [],
+  secondaryFeeRecipients: []
+}
 
 const tenPieces = 10;
 
@@ -48,15 +54,19 @@ describe("ERC20 interactions", function () {
     let Erc20;
     let erc20;
 
-    let feeRecipients;
-    let feeBps;
+    let feeRecipients = {
+      primaryFeeBPS: [],
+      secondaryFeeBPS: [],
+      primaryFeeRecipients: [],
+      secondaryFeeRecipients: []
+    }
 
     beforeEach(async function () {
       [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
         await ethers.getSigners();
 
-      feeRecipients = [ContractOwner.address, testArtist.address];
-      feeBps = [1000, 9000];
+      feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feeRecipients.primaryFeeBPS = [1000, 9000];
 
       Blueprint = await ethers.getContractFactory("BlueprintV12");
       blueprint = await Blueprint.deploy();
@@ -86,11 +96,9 @@ describe("ERC20 interactions", function () {
           0,
           0,
           0,
-          0
+          0,
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(0, feeRecipients, feeBps, [], []);
       await blueprint.connect(ContractOwner).beginSale(0);
     });
     it("1: should begin sale of blueprint", async function () {
@@ -128,11 +136,9 @@ describe("ERC20 interactions", function () {
           0,
           0,
           0,
-          0
+          0,
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(1, feeRecipients, feeBps, feeRecipients, feeBps);
       await expect(
         blueprint.connect(ContractOwner).pauseSale(1)
       ).to.be.revertedWith("Sale not ongoing");

--- a/test/admin-tests.js
+++ b/test/admin-tests.js
@@ -8,21 +8,22 @@ const testHash = "fbejgnvnveorjgnt";
 const tenThousandPieces = 10000;
 const zero = BigNumber.from(0).toString();
 
-const emptyFeeRecipients = [];
-const emptyFeePercentages = [];
-
 describe("Admin Blueprint Tests", function () {
   let Blueprint;
   let blueprint;
-  let feeRecipients;
-  let feeBps;
+  let feeRecipients = {
+    primaryFeeBPS: [],
+    secondaryFeeBPS: [],
+    primaryFeeRecipients: [],
+    secondaryFeeRecipients: []
+  }
 
   beforeEach(async function () {
     [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
       await ethers.getSigners();
 
-    feeRecipients = [ContractOwner.address, testArtist.address];
-    feeBps = [1000, 9000];
+    feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+    feeRecipients.primaryFeeBPS = [1000, 9000];
 
     Blueprint = await ethers.getContractFactory("BlueprintV12");
     blueprint = await Blueprint.deploy();
@@ -43,11 +44,9 @@ describe("Admin Blueprint Tests", function () {
         0,
         0,
         0,
-        0
+        0,
+        feeRecipients
       );
-    await blueprint
-      .connect(user2)
-      .setFeeRecipients(0, feeRecipients, feeBps, [], []);
     let result = await blueprint.blueprints(0);
     expect(result.artist).to.be.equal(testArtist.address);
   });
@@ -73,11 +72,9 @@ describe("Admin Blueprint Tests", function () {
         0,
         0,
         0,
-        0
+        0,
+        feeRecipients
       );
-    await blueprint
-      .connect(ContractOwner)
-      .setFeeRecipients(0, feeRecipients, feeBps, [], []);
     let updatedUri = "http://updatedUri/";
     await blueprint.connect(ContractOwner).updateMinterAddress(user2.address);
     await blueprint
@@ -90,7 +87,7 @@ describe("Admin Blueprint Tests", function () {
     let updatedUri = "http://updatedUri/";
     await expect(
       blueprint.connect(ContractOwner).updateBlueprintTokenUri(0, updatedUri)
-    ).to.be.revertedWith("blueprint not prepared");
+    ).to.be.revertedWith("not prepared");
   });
   it("2.c: should lock token URI", async function () {
     await blueprint
@@ -106,17 +103,15 @@ describe("Admin Blueprint Tests", function () {
         0,
         0,
         0,
-        0
+        0,
+        feeRecipients
       );
-    await blueprint
-      .connect(ContractOwner)
-      .setFeeRecipients(0, feeRecipients, feeBps, [], []);
     let updatedUri = "http://updatedUri/";
 
     await blueprint.connect(ContractOwner).lockBlueprintTokenUri(0);
     await expect(
       blueprint.connect(ContractOwner).updateBlueprintTokenUri(0, updatedUri)
-    ).to.be.revertedWith("blueprint URI locked");
+    ).to.be.revertedWith("URI locked");
   });
   // it("2.d: should allow platform to update base token uri", async function () {
   //   await blueprint
@@ -159,7 +154,8 @@ describe("Admin Blueprint Tests", function () {
         0,
         0,
         0,
-        0
+        0,
+        feeRecipients
       );
     let randomSeed = "randomSeedHash";
     await expect(blueprint.revealBlueprintSeed(0, randomSeed))
@@ -227,7 +223,8 @@ describe("Admin Blueprint Tests", function () {
         0,
         0,
         0,
-        0
+        0,
+        feeRecipients
       );
     const newPrice = oneEth.mul(2);
     const newMintAmountArtist = 1;

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -11,6 +11,12 @@ const testUri = "https://randomUri/";
 const testHash = "fbejgnvnveorjgnt";
 const tenThousandPieces = 10000;
 const zero = BigNumber.from(0).toString();
+const emptyFeeRecipients = {
+  primaryFeeBPS: [],
+  secondaryFeeBPS: [],
+  primaryFeeRecipients: [],
+  secondaryFeeRecipients: []
+}
 
 const tenPieces = 10;
 
@@ -42,14 +48,18 @@ describe("Merkleroot Tests", function () {
   describe("A: Mint all whitelisted", function () {
     let Blueprint;
     let blueprint;
-    let feeRecipients;
-    let feeBps;
+    let feeRecipients = {
+      primaryFeeBPS: [],
+      secondaryFeeBPS: [],
+      primaryFeeRecipients: [],
+      secondaryFeeRecipients: []
+    }
     before(async function () {
       [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
         await ethers.getSigners();
 
-      feeRecipients = [ContractOwner.address, testArtist.address];
-      feeBps = [1000, 9000];
+      feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feeRecipients.primaryFeeBPS = [1000, 9000];
       Blueprint = await ethers.getContractFactory("BlueprintV12");
       blueprint = await Blueprint.deploy();
       blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address);
@@ -66,11 +76,9 @@ describe("Merkleroot Tests", function () {
           0,
           0,
           0,
-          0
+          0,
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(0, feeRecipients, feeBps, [], []);
     });
     let capacity = tenThousandPieces;
     let index = BigNumber.from(0);
@@ -127,7 +135,8 @@ describe("Merkleroot Tests", function () {
           0,
           0,
           0,
-          0
+          0,
+          emptyFeeRecipients
         );
       let result = await blueprint.blueprints(1);
       expect(result.saleState.toString()).to.be.equal(

--- a/test/premint-tests.js
+++ b/test/premint-tests.js
@@ -11,6 +11,12 @@ const testUri = "https://randomUri/";
 const testHash = "fbejgnvnveorjgnt";
 const oneThousandPieces = 1000;
 const zero = BigNumber.from(0).toString();
+const emptyFeeRecipients = {
+  primaryFeeBPS: [],
+  secondaryFeeBPS: [],
+  primaryFeeRecipients: [],
+  secondaryFeeRecipients: []
+}
 const testPlatformPreSaleMintQuantity = 15;
 const testArtistPreSaleMintQuantity = 17;
 const testMaxPurchaseAmount = 0;
@@ -37,15 +43,19 @@ describe("Blueprint presale minting", function () {
   describe("A: Presale minting functionality tests", function () {
     let Blueprint;
     let blueprint;
-    let feeRecipients;
-    let feeBps;
+    let feeRecipients = {
+      primaryFeeBPS: [],
+      secondaryFeeBPS: [],
+      primaryFeeRecipients: [],
+      secondaryFeeRecipients: []
+    }
 
     beforeEach(async function () {
       [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
         await ethers.getSigners();
 
-      feeRecipients = [ContractOwner.address, testArtist.address];
-      feeBps = [1000, 9000];
+      feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feeRecipients.primaryFeeBPS = [1000, 9000];
 
       Blueprint = await ethers.getContractFactory("BlueprintV12");
       blueprint = await Blueprint.deploy();
@@ -63,11 +73,9 @@ describe("Blueprint presale minting", function () {
           testArtistPreSaleMintQuantity,
           testPlatformPreSaleMintQuantity,
           testMaxPurchaseAmount,
-          0
+          0,
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(0, feeRecipients, feeBps, [], []);
     });
     it("1: Should allow the platform to mint presale", async function () {
       await blueprint
@@ -128,7 +136,7 @@ describe("Blueprint presale minting", function () {
         blueprint
           .connect(testArtist)
           .preSaleMint(0, testArtistPreSaleMintQuantity)
-      ).to.be.revertedWith("Must be prepared and not started");
+      ).to.be.revertedWith("Sale must be not started");
     });
     it("7: Should not allow presale mint when sale paused", async function () {
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -137,7 +145,7 @@ describe("Blueprint presale minting", function () {
         blueprint
           .connect(testArtist)
           .preSaleMint(0, testArtistPreSaleMintQuantity)
-      ).to.be.revertedWith("Must be prepared and not started");
+      ).to.be.revertedWith("Sale must be not started");
     });
   });
 });

--- a/test/sales-tests.js
+++ b/test/sales-tests.js
@@ -12,6 +12,12 @@ const testUri = "https://randomUri/";
 const testHash = "fbejgnvnveorjgnt";
 const oneThousandPieces = 1000;
 const tenPieces = 10;
+const emptyFeeRecipients = {
+  primaryFeeBPS: [],
+  secondaryFeeBPS: [],
+  primaryFeeRecipients: [],
+  secondaryFeeRecipients: []
+}
 
 const sale_started = BigNumber.from(2).toString();
 const sale_paused = BigNumber.from(3).toString();
@@ -26,6 +32,14 @@ function hashToken(account, quantity) {
 }
 
 describe("Blueprint Sales", function () {
+
+  let feeRecipients = {
+    primaryFeeBPS: [],
+    secondaryFeeBPS: [],
+    primaryFeeRecipients: [],
+    secondaryFeeRecipients: []
+  }
+
   before(async function () {
     this.accounts = await ethers.getSigners();
     this.merkleTree = new MerkleTree(
@@ -37,15 +51,13 @@ describe("Blueprint Sales", function () {
   describe("A: Basic Blueprint sale tests", function () {
     let Blueprint;
     let blueprint;
-    let feeRecipients;
-    let feeBps;
 
     beforeEach(async function () {
       [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
         await ethers.getSigners();
 
-      feeRecipients = [ContractOwner.address, testArtist.address];
-      feeBps = [1000, 9000];
+      feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feeRecipients.primaryFeeBPS = [1000, 9000];
 
       Blueprint = await ethers.getContractFactory("BlueprintV12");
       blueprint = await Blueprint.deploy();
@@ -63,11 +75,9 @@ describe("Blueprint Sales", function () {
           0,
           0,
           0,
-          0
+          0,
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(0, feeRecipients, feeBps, [], []);
       await blueprint.connect(ContractOwner).beginSale(0);
     });
     it("1: should begin sale of blueprint", async function () {
@@ -111,7 +121,8 @@ describe("Blueprint Sales", function () {
           0,
           0,
           0,
-          0
+          0,
+          emptyFeeRecipients
         );
       await expect(
         blueprint.connect(ContractOwner).pauseSale(1)
@@ -204,7 +215,8 @@ describe("Blueprint Sales", function () {
             0,
             0,
             0,
-            0
+            0,
+            emptyFeeRecipients
           );
         await blueprint.connect(ContractOwner).beginSale(1);
         await blueprint.setAsyncFeeRecipient(testPlatform.address);
@@ -243,15 +255,13 @@ describe("Blueprint Sales", function () {
   describe("C: Expired timestamp sales tests", function () {
     let Blueprint;
     let blueprint;
-    let feeRecipients;
-    let feeBps;
 
     beforeEach(async function () {
       [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
         await ethers.getSigners();
 
-      feeRecipients = [ContractOwner.address, testArtist.address];
-      feeBps = [1000, 9000];
+      feeRecipients.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feeRecipients.primaryFeeBPS = [1000, 9000];
 
       Blueprint = await ethers.getContractFactory("BlueprintV12");
       blueprint = await Blueprint.deploy();
@@ -273,11 +283,9 @@ describe("Blueprint Sales", function () {
           0,
           0,
           0,
-          BigNumber.from(nextBlockTimestamp).add(10)
+          BigNumber.from(nextBlockTimestamp).add(10),
+          feeRecipients
         );
-      await blueprint
-        .connect(ContractOwner)
-        .setFeeRecipients(0, feeRecipients, feeBps, [], []);
       await blueprint.connect(ContractOwner).beginSale(0);
     });
     // TODO(sorend): strategy for testing these cases with ~300s inaccuracy in hardhat newtwork timestamp

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@ensdomains/ens@^0.4.4":
   version "0.4.5"
   resolved "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz"
@@ -1092,6 +1097,11 @@ ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2212,7 +2222,7 @@ chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2320,6 +2330,15 @@ cli-table3@^0.5.0:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-table3@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
+  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -2881,6 +2900,11 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encode-utf8@^1.0.2:
   version "1.0.3"
@@ -4327,6 +4351,14 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+hardhat-contract-sizer@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.6.1.tgz#2b0046a55fa1ec96f19fdab7fde372377401c874"
+  integrity sha512-b8wS7DBvyo22kmVwpzstAQTdDCThpl/ySBqZh5ga9Yxjf61/uTL12TEg5nl7lDeWy73ntEUzxMwY6XxbQEc2wA==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
+
 hardhat-deploy@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.9.1.tgz#878bb10ef1bfcfee892477c2133295a250721672"
@@ -4904,6 +4936,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-function@^1.0.1:
   version "1.0.2"
@@ -7758,6 +7795,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trim@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz"
@@ -7822,6 +7868,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We want `setFeeRecipients` to be callable at anytime (as long as the Blueprint has been prepared), and we want `feeRecipients` to be optionally provided at the time of preparing the Blueprint. A few notes:

- We had to add a new `Fees` struct to the contract to avoid stack depth errors in `prepareBlueprint`
- `setFeeRecipients` is now `public` because we call it from `prepareBlueprint`
- We are VERY close the contract size limit now. That's why the diff includes a lot of tinkering with error messages, removing some view functions etc. to bring the contract down to size. I think some of the merkle tree changes might actually reduce the contract size which would help us out a lot, but otherwise we might need to consider porting some of our pure validation logic to a `BlueprintStateChecker` library to keep the size of this contract within bounds.