### PR TITLE
Make PreSale Mint Callable During pre-sale or public sale

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -486,10 +486,11 @@ contract BlueprintV12 is
         _mintQuantity(blueprintID, quantity, msg.sender);
     }
 
+    // TODO: @conlan, do you want to keep the naming here to preserve the interface even though the meaning of this function has changed?
     function preSaleMint(uint256 blueprintID, uint32 quantity) external {
         require(
-            _isBlueprintPreparedAndNotStarted(blueprintID),
-            "Sale must be not started"
+            _isBlueprintPreparedAndNotStarted(blueprintID) || _isSaleOngoing(blueprintID),
+            "Must be presale or public sale"
         );
         require(
             minterAddress == msg.sender ||

--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.4;
 
 import "./abstract/HasSecondarySaleFees.sol";
-
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -60,7 +59,6 @@ contract BlueprintV12 is
         bytes32 merkleroot;
         SaleState saleState;    
         Fees feeRecipientInfo;
-        mapping(address => bool) claimedWhitelistedPieces;
     }
 
     event BlueprintSeed(uint256 blueprintID, string randomSeed);
@@ -116,13 +114,13 @@ contract BlueprintV12 is
 
     modifier BuyerWhitelistedOrSaleStarted(
         uint256 _blueprintID,
-        uint32 _quantity,
+        uint32 _whitelistedQuantity,
         bytes32[] calldata proof
     ) {
         require(
             _isSaleOngoing(_blueprintID) ||
                 (_isBlueprintPreparedAndNotStarted(_blueprintID) &&
-                    userWhitelisted(_blueprintID, uint256(_quantity), proof)),
+                    userWhitelisted(_blueprintID, uint256(_whitelistedQuantity), proof)),
             "not available to purchase"
         );
         _;
@@ -203,10 +201,6 @@ contract BlueprintV12 is
         bytes32[] calldata proof
     ) internal view returns (bool) {
         require(proof.length != 0, "no proof provided");
-        require(
-            !blueprints[_blueprintID].claimedWhitelistedPieces[msg.sender],
-            "already claimed"
-        );
         bytes32 _merkleroot = blueprints[_blueprintID].merkleroot;
         return _verify(_leaf(msg.sender, _quantity), _merkleroot, proof);
     }
@@ -321,12 +315,13 @@ contract BlueprintV12 is
         setFeeRecipients(_blueprintID, _feeRecipientInfo);
     }
 
-    function resetClaimedStatus (
+    // TODO: this doesn't apply really with variable presale mints probably delete. We could change this to a method for the minter to overwrite any users whitelisted
+    //       amount arbitrarily but that seems a bit dangerous//not decentralized. (i.e. minter could wipe all whitelisted users for no reason on any Blueprint)
+    /*function resetClaimedStatus (
         uint256 _blueprintID,
         address _minter
     ) external onlyRole(MINTER_ROLE) {
-        blueprints[_blueprintID].claimedWhitelistedPieces[_minter] = false;
-    }
+    }*/
 
     function updateBlueprintArtist (
         uint256 _blueprintID,
@@ -417,73 +412,83 @@ contract BlueprintV12 is
         emit SaleUnpaused(blueprintID);
     }
 
+    function _updateMerkleRootForPurchase(
+        uint256 blueprintID,
+        bytes32[] memory oldProof,
+        uint32 remainingWhitelistAmount
+    ) 
+        internal
+    {
+        bool[] memory proofFlags = new bool[](oldProof.length);
+        bytes32[] memory leaves = new bytes32[](1);
+        leaves[0] = _leaf(msg.sender, uint256(remainingWhitelistAmount));
+        blueprints[blueprintID].merkleroot = MerkleProof.processMultiProof(oldProof, proofFlags, leaves);
+    }
+
     function purchaseBlueprintsTo(
         uint256 blueprintID,
-        uint32 quantity,
+        uint32 purchaseQuantity,
+        uint32 whitelistedQuantity,
         uint256 tokenAmount,
         bytes32[] calldata proof,
         address nftRecipient
     )
         external
         payable
-        BuyerWhitelistedOrSaleStarted(blueprintID, quantity, proof)
-        isQuantityAvailableForPurchase(blueprintID, quantity)
+        BuyerWhitelistedOrSaleStarted(blueprintID, whitelistedQuantity, proof)
+        isQuantityAvailableForPurchase(blueprintID, purchaseQuantity)
     {
+        require(purchaseQuantity <= whitelistedQuantity, "cannot purchase > whitelisted amount");
         require(
             blueprints[blueprintID].maxPurchaseAmount == 0 ||
-                quantity <= blueprints[blueprintID].maxPurchaseAmount,
+                purchaseQuantity <= blueprints[blueprintID].maxPurchaseAmount,
             "cannot buy > maxPurchaseAmount in one tx"
         );
 
         require (tx.origin == msg.sender, "purchase not callable from other contract");
 
-        address _artist = blueprints[blueprintID].artist;
+        address artist = blueprints[blueprintID].artist;
         _confirmPaymentAmountAndSettleSale(
             blueprintID,
-            quantity,
+            purchaseQuantity,
             tokenAmount,
-            _artist
+            artist
         );
-
-        if (blueprints[blueprintID].saleState == SaleState.not_started) {
-            blueprints[blueprintID].claimedWhitelistedPieces[msg.sender] = true;
-        }
-
-        _mintQuantity(blueprintID, quantity, nftRecipient);
+        _mintQuantity(blueprintID, purchaseQuantity, nftRecipient);
+        _updateMerkleRootForPurchase(blueprintID, proof, whitelistedQuantity - purchaseQuantity);
     }
 
     function purchaseBlueprints(
         uint256 blueprintID,
-        uint32 quantity,
+        uint32 purchaseQuantity,
+        uint32 whitelistedQuantity,
         uint256 tokenAmount,
         bytes32[] calldata proof
     )
         external
         payable
-        BuyerWhitelistedOrSaleStarted(blueprintID, quantity, proof)
-        isQuantityAvailableForPurchase(blueprintID, quantity)
+        BuyerWhitelistedOrSaleStarted(blueprintID, whitelistedQuantity, proof)
+        isQuantityAvailableForPurchase(blueprintID, purchaseQuantity)
     {
+        require(purchaseQuantity <= whitelistedQuantity, "cannot purchase > whitelisted amount");
         require(
             blueprints[blueprintID].maxPurchaseAmount == 0 ||
-                quantity <= blueprints[blueprintID].maxPurchaseAmount,
+                purchaseQuantity <= blueprints[blueprintID].maxPurchaseAmount,
             "cannot buy > maxPurchaseAmount in one tx"
         );
 
         require (tx.origin == msg.sender, "purchase not callable from other contract");
 
-        address _artist = blueprints[blueprintID].artist;
+        address artist = blueprints[blueprintID].artist;
         _confirmPaymentAmountAndSettleSale(
             blueprintID,
-            quantity,
+            purchaseQuantity,
             tokenAmount,
-            _artist
+            artist
         );
 
-        if (blueprints[blueprintID].saleState == SaleState.not_started) {
-            blueprints[blueprintID].claimedWhitelistedPieces[msg.sender] = true;
-        }
-
-        _mintQuantity(blueprintID, quantity, msg.sender);
+        _mintQuantity(blueprintID, purchaseQuantity, msg.sender);
+        _updateMerkleRootForPurchase(blueprintID, proof, whitelistedQuantity - purchaseQuantity);
     }
 
     // TODO: @conlan, do you want to keep the naming here to preserve the interface even though the meaning of this function has changed?

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -41,19 +41,15 @@ module.exports = {
   namedAccounts: {
     deployer: 0,
   },
-  // networks: {
-  //   hardhat: {
-  //     allowUnlimitedContractSize: true,
-  //     initialBaseFeePerGas: 0,
-  //   },
-  //   rinkeby: {
-  //     url: alchemyUrl,
-  //     accounts: [`0x${rinkebyPrivateKey}`],
-  //   },
-  // },
-  // etherscan: {
-  //   // Your API key for Etherscan
-  //   // Obtain one at https://etherscan.io/
-  //   apiKey: etherscanApiKey,
-  // },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+      initialBaseFeePerGas: 0,
+    }
+  },
+  etherscan: {
+    // Your API key for Etherscan
+    // Obtain one at https://etherscan.io/
+    apiKey: etherscanApiKey,
+  }
 };

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "coverage": "hardhat coverage",
     "deploy": "hardhat deploy",
     "deploy-rinkeby": "hardhat deploy --network rinkeby",
-    "verify": "npx hardhat verify --network rinkeby"
+    "verify": "npx hardhat verify --network rinkeby",
+    "clean": "hardhat clean"
   },
   "dependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/contracts": "^4.7.0",
     "@openzeppelin/contracts-upgradeable": "^4.3.2",
     "@openzeppelin/hardhat-upgrades": "^1.10.0",
     "chai": "^4.3.4",

--- a/test/ERC20-tests.js
+++ b/test/ERC20-tests.js
@@ -146,7 +146,7 @@ describe("ERC20 interactions", function () {
     it("5: should allow users to purchase blueprints", async function () {
       await blueprint
         .connect(user2)
-        .purchaseBlueprints(0, tenPieces, tenEth, []);
+        .purchaseBlueprints(0, tenPieces, tenPieces, tenEth, []);
       let result = await blueprint.blueprints(0);
       let expectedCap = fiveHundredPieces - tenPieces;
       expect(result.capacity.toString()).to.be.equal(
@@ -166,7 +166,7 @@ describe("ERC20 interactions", function () {
 
         await blueprint
           .connect(user2)
-          .purchaseBlueprints(0, tenPieces, tenEth, []);
+          .purchaseBlueprints(0, tenPieces, tenPieces, tenEth, []);
         let expectedAmount = BigNumber.from(ownerBal);
         let newOwnerBal = await erc20.balanceOf(ContractOwner.address);
         expect(newOwnerBal.toString()).to.be.equal(
@@ -182,20 +182,21 @@ describe("ERC20 interactions", function () {
         await expect(
           blueprint
             .connect(user2)
-            .purchaseBlueprints(0, tenPieces, 10, [], { value: 10 })
+            .purchaseBlueprints(0, tenPieces, tenPieces, 10, [], { value: 10 })
         ).to.be.revertedWith("cannot specify eth amount");
       });
       it("3: should not allow purchase of more than capacity", async function () {
         let fiveHundredEth = fiveHundredPieces.mul(oneEth);
         await blueprint
           .connect(user1)
-          .purchaseBlueprints(0, fiveHundredPieces, fiveHundredEth, []);
+          .purchaseBlueprints(0, fiveHundredPieces, fiveHundredPieces, fiveHundredEth, []);
 
         await expect(
           blueprint
             .connect(user2)
             .purchaseBlueprints(
               0,
+              fiveHundredPieces.add(BigNumber.from(1)),
               fiveHundredPieces.add(BigNumber.from(1)),
               fiveHundredEth.add(oneEth),
               []
@@ -204,7 +205,7 @@ describe("ERC20 interactions", function () {
       });
       it("4: should not allow sale for less than price", async function () {
         await expect(
-          blueprint.connect(user2).purchaseBlueprints(0, tenPieces, oneEth, [])
+          blueprint.connect(user2).purchaseBlueprints(0, tenPieces, tenPieces, oneEth, [])
         ).to.be.revertedWith("Purchase amount must match price");
       });
     });

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -36,7 +36,6 @@ function hashToken(account, quantity) {
 
 describe("Merkleroot Tests", function () {
   before(async function () {
-    console.log("A");
     this.accounts = await ethers.getSigners();
     this.merkleTree = new MerkleTree(
       Object.entries(mapping).map((mapping) => hashToken(...mapping)),

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -1,4 +1,3 @@
-const mapping = require("./merkle_mapping.json");
 const { expect } = require("chai");
 const { MerkleTree } = require("merkletreejs");
 const keccak256 = require("keccak256");
@@ -34,7 +33,22 @@ function hashToken(account, quantity) {
   );
 }
 
+function computeMerkleFromMapping(mapping) {
+  return new MerkleTree(
+    Object.entries(mapping).map((mapping) => hashToken(...mapping)),
+    keccak256,
+    { sortPairs: true }
+  );
+}
+
 describe("Merkleroot Tests", function () {
+
+  // whitelist mapping
+  let mapping = {
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8": "10",
+    "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC": "2"
+  }
+
   before(async function () {
     this.accounts = await ethers.getSigners();
     this.merkleTree = new MerkleTree(
@@ -79,48 +93,15 @@ describe("Merkleroot Tests", function () {
           feeRecipients
         );
     });
-    let capacity = tenThousandPieces;
-    let index = BigNumber.from(0);
-    for (const [account, quantity] of Object.entries(mapping)) {
-      it("element", async function () {
-        let buyer;
-        if (user1.address == account) {
-          buyer = user1;
-        } else {
-          buyer = user2;
-        }
-        const proof = this.merkleTree.getHexProof(hashToken(account, quantity));
-        const blueprintValue = BigNumber.from(quantity).mul(oneEth);
-        await blueprint
-          .connect(buyer)
-          .purchaseBlueprints(0, quantity, 0, proof, { value: blueprintValue });
-        let result = await blueprint.blueprints(0);
-        capacity = capacity - quantity;
-        expect(result.capacity.toString()).to.be.equal(
-          BigNumber.from(capacity).toString()
-        );
-        //should end on the next index
-        //this user owns 0 - 9, next user will own 10 - x
-        index = index.add(BigNumber.from(quantity));
-        expect(result.erc721TokenIndex.toString()).to.be.equal(
-          BigNumber.from(index).toString()
-        );
-        await expect(
-          blueprint.connect(buyer).purchaseBlueprints(0, quantity, 0, proof, {
-            value: blueprintValue,
-          })
-        ).to.be.revertedWith("already claimed");
-      });
-    }
-    it("2: should not allow non whitelisted user", async function () {
-      const proof = this.merkleTree.getHexProof(hashToken(user2.address, 1));
+    it("1: should not allow non whitelisted user", async function () {
+      const proof = this.merkleTree.getHexProof(hashToken(user2.address, 2));
       await expect(
         blueprint
           .connect(user3)
-          .purchaseBlueprints(0, 1, 0, proof, { value: oneEth })
+          .purchaseBlueprints(0, 1, 1, 0, proof, { value: oneEth })
       ).to.be.revertedWith("not available to purchase");
     });
-    it("3: should not allow buyer when no merkle provided", async function () {
+    it("2: should not allow buyer when no merkle provided", async function () {
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
@@ -137,35 +118,88 @@ describe("Merkleroot Tests", function () {
           0,
           emptyFeeRecipients
         );
-      let result = await blueprint.blueprints(1);
-      expect(result.saleState.toString()).to.be.equal(
-        BigNumber.from(1).toString()
-      );
-      expect(result.artist).to.be.equal(user3.address);
-      expect(result.price.toString()).to.be.equal(oneEth.div(2).toString());
-      expect(result.capacity.toString()).to.be.equal(
-        BigNumber.from(tenThousandPieces).toString()
-      );
-      expect(result.erc721TokenIndex.toString()).to.be.equal(
-        tenThousandPieces.toString()
-      );
-      expect(result.baseTokenUri).to.be.equal(testUri);
 
       const proof = this.merkleTree.getHexProof(hashToken(user1.address, 10));
       const blueprintValue = BigNumber.from(1).mul(oneEth).div(2);
       await expect(
         blueprint
           .connect(user1)
-          .purchaseBlueprints(1, 1, 0, proof, { value: blueprintValue })
+          .purchaseBlueprints(1, 1, 1, 0, proof, { value: blueprintValue })
       ).to.be.revertedWith("not available to purchase");
     });
-    it("4: should revert when no proof provided", async function () {
+    it("3: should revert when no proof provided", async function () {
       const proof = this.merkleTree.getHexProof(hashToken(user1.address, 1));
       await expect(
         blueprint
           .connect(user3)
-          .purchaseBlueprints(0, 1, 0, proof, { value: oneEth })
+          .purchaseBlueprints(0, 1, 1, 0, proof, { value: oneEth })
       ).to.be.revertedWith("no proof provided");
     });
+    let capacity = tenThousandPieces;
+    let index = BigNumber.from(0);
+    for (const [account, quantity] of Object.entries(mapping)) {
+      it("element", async function () {
+        let buyer;
+        if (user1.address == account) {
+          buyer = user1;
+        } else {
+          buyer = user2;
+        }
+
+        // purchase half of whitelisted amount
+        let quantityToPurchase = (parseInt(quantity)/2).toString()
+        let proof = this.merkleTree.getHexProof(hashToken(account, quantity));
+        const blueprintValue = BigNumber.from(quantityToPurchase).mul(oneEth);
+        await blueprint
+          .connect(buyer)
+          .purchaseBlueprints(0, quantityToPurchase, quantity, 0, proof, { value: blueprintValue });
+
+        // assert on state changes of first purchase
+        let result = await blueprint.blueprints(0);
+        capacity = capacity - quantityToPurchase;
+        expect(result.capacity.toString()).to.be.equal(
+          BigNumber.from(capacity).toString()
+        );
+        mapping[account] = (parseInt(quantity) - parseInt(quantityToPurchase)).toString()
+        this.merkleTree = computeMerkleFromMapping(mapping)
+        expect(result.merkleroot).to.be.equal(this.merkleTree.getHexRoot());
+        //should end on the next index
+        //this user owns 0 - 9, next user will own 10 - x
+        index = index.add(BigNumber.from(quantityToPurchase));
+        expect(result.erc721TokenIndex.toString()).to.be.equal(
+          BigNumber.from(index).toString()
+        );
+
+        // purchase second half of whitelisted amount
+        proof = this.merkleTree.getHexProof(hashToken(account, quantityToPurchase));
+        await blueprint
+          .connect(buyer)
+          .purchaseBlueprints(0, quantityToPurchase, quantityToPurchase, 0, proof, { value: blueprintValue });
+
+        // assert on state changes of second purchase
+        result = await blueprint.blueprints(0);
+        capacity = capacity - quantityToPurchase;
+        expect(result.capacity.toString()).to.be.equal(
+          BigNumber.from(capacity).toString()
+        );
+        mapping[account] = "0"
+        this.merkleTree = computeMerkleFromMapping(mapping)
+        expect(result.merkleroot).to.be.equal(this.merkleTree.getHexRoot());
+        //should end on the next index
+        //this user owns 0 - 9, next user will own 10 - x
+        index = index.add(BigNumber.from(quantityToPurchase));
+        expect(result.erc721TokenIndex.toString()).to.be.equal(
+          BigNumber.from(index).toString()
+        );
+
+        // Assert that we cannot buy anymore, not the best assertion,
+        proof = this.merkleTree.getHexProof(hashToken(account, "0"));
+        await expect(
+          blueprint.connect(buyer).purchaseBlueprints(0, 1, 1, 0, proof, {
+            value: blueprintValue,
+          })
+        ).to.be.revertedWith("not available to purchase");
+      });
+    }
   });
 });

--- a/test/sales-tests.js
+++ b/test/sales-tests.js
@@ -132,7 +132,7 @@ describe("Blueprint Sales", function () {
       let blueprintValue = BigNumber.from(tenPieces).mul(oneEth);
       await blueprint
         .connect(user2)
-        .purchaseBlueprints(0, tenPieces, 0, [], { value: blueprintValue });
+        .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: blueprintValue });
       let result = await blueprint.blueprints(0);
       let expectedCap = oneThousandPieces - tenPieces;
       expect(result.capacity.toString()).to.be.equal(
@@ -150,7 +150,7 @@ describe("Blueprint Sales", function () {
       await expect(
         blueprint
           .connect(user2)
-          .purchaseBlueprints(0, tenPieces, 0, [], { value: blueprintValue })
+          .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: blueprintValue })
       ).to.be.revertedWith("not available to purchase");
     });
     describe("B: Sale + purchase interactions", function () {
@@ -160,7 +160,7 @@ describe("Blueprint Sales", function () {
         let blueprintValue = BigNumber.from(tenPieces).mul(oneEth);
         await blueprint
           .connect(user2)
-          .purchaseBlueprints(0, tenPieces, 0, [], { value: blueprintValue });
+          .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: blueprintValue });
         let expectedAmount = BigNumber.from(ownerBal);
         let newOwnerBal = await ContractOwner.getBalance();
         expect(newOwnerBal.toString()).to.be.equal(
@@ -177,7 +177,7 @@ describe("Blueprint Sales", function () {
         await expect(
           blueprint
             .connect(user2)
-            .purchaseBlueprints(0, tenPieces, 10, [], { value: blueprintValue })
+            .purchaseBlueprints(0, tenPieces, tenPieces, 10, [], { value: blueprintValue })
         ).to.be.revertedWith("cannot specify token amount");
       });
       it("3: should not allow purchase of more than capacity", async function () {
@@ -185,7 +185,7 @@ describe("Blueprint Sales", function () {
         let fiveHundredEth = fiveHundredPieces.mul(oneEth);
         await blueprint
           .connect(user1)
-          .purchaseBlueprints(0, fiveHundredPieces, 0, [], {
+          .purchaseBlueprints(0, fiveHundredPieces, fiveHundredPieces, 0, [], {
             value: fiveHundredEth,
           });
 
@@ -194,6 +194,7 @@ describe("Blueprint Sales", function () {
             .connect(user2)
             .purchaseBlueprints(
               0,
+              fiveHundredPieces.add(BigNumber.from(1)),
               fiveHundredPieces.add(BigNumber.from(1)),
               0,
               [],
@@ -225,7 +226,7 @@ describe("Blueprint Sales", function () {
         let blueprintValue = BigNumber.from(tenPieces).mul(oneEth);
         await blueprint
           .connect(user2)
-          .purchaseBlueprints(1, tenPieces, 0, [], { value: blueprintValue });
+          .purchaseBlueprints(1, tenPieces, tenPieces, 0, [], { value: blueprintValue });
         let expectedAmount = BigNumber.from(testPlatformBal);
         let newPlatformBal = await testPlatform.getBalance();
         expect(newPlatformBal.toString()).to.be.equal(
@@ -241,7 +242,7 @@ describe("Blueprint Sales", function () {
         let blueprintValue = BigNumber.from(tenPieces).mul(oneEth);
         await blueprint
           .connect(user2)
-          .purchaseBlueprints(0, tenPieces, 0, [], { value: blueprintValue });
+          .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: blueprintValue });
 
         await blueprint
           .connect(ContractOwner)
@@ -312,7 +313,7 @@ describe("Blueprint Sales", function () {
       await expect (
         blueprint
           .connect(user2)
-          .purchaseBlueprints(0, tenPieces, 0, [], { value: BigNumber.from(tenPieces).mul(oneEth) })
+          .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: BigNumber.from(tenPieces).mul(oneEth) })
       ).to.be.revertedWith("not available to purchase");
     });
     // TODO: consider a test that shows you can't pause a sale who's end timestamp has passed...but maybe we don't want this if we want the minter to be able

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz#92df481362e366c388fc02133cf793029c744cea"
   integrity sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ==
 
-"@openzeppelin/contracts@^4.2.0":
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.1.tgz"
-  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
+"@openzeppelin/contracts@^4.7.0":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.2.tgz#7587416fe2d35abf574193515b8971bfe9f64bc7"
+  integrity sha512-4n/JL9izql8303mPqPdubuna/DWEMbmOzWYUWyCPhjhiEr2w3nQrjE7vZz1fBF+wzzP6dZbIcsgqACk53c9FGA==
 
 "@openzeppelin/hardhat-upgrades@^1.10.0":
   version "1.10.0"


### PR DESCRIPTION
This PR address the following contract ammendmant: "preSaleMint() should instead be callable during presale or public sale (in case artist wants to let collectors have access to lower edition numbers before they mint their allotment)".