### PR TITLE
HasSecondarySaleFees Interface Support and Optimizations

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.4;
 
+import "hardhat/console.sol";
 import "./abstract/HasSecondarySaleFees.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
@@ -186,7 +187,7 @@ contract BlueprintV12 is
         view
         returns (bool)
     {
-        return _saleEndTimestamp == 0 || _saleEndTimestamp > block.timestamp;
+        return _saleEndTimestamp > block.timestamp || _saleEndTimestamp == 0;
     }
 
     function _isBlueprintPreparedAndNotStarted(uint256 _blueprintID)
@@ -458,11 +459,10 @@ contract BlueprintV12 is
         _updateMerkleRootForPurchase(blueprintID, proof, whitelistedQuantity - purchaseQuantity);
     }
 
-    // TODO: @conlan, do you want to keep the naming here to preserve the interface even though the meaning of this function has changed?
-    function preSaleMint(
+    function artistMint(
         uint256 blueprintID,
         uint32 quantity
-    ) 
+    )
         external
         nonReentrant 
     {
@@ -853,6 +853,7 @@ contract BlueprintV12 is
         )
         returns (bool)
     {
+        // console.log(type(HasSecondarySaleFees).interfaceId);
         return
             ERC721Upgradeable.supportsInterface(interfaceId) ||
             ERC165StorageUpgradeable.supportsInterface(interfaceId) ||

--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.4;
 
-import "hardhat/console.sol";
 import "./abstract/HasSecondarySaleFees.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
@@ -121,9 +120,10 @@ contract BlueprintV12 is
         bytes32[] calldata proof
     ) {
         require(
+            // Sale must be ongoing OR
             _isSaleOngoing(_blueprintID) ||
-                (_isBlueprintPreparedAndNotStarted(_blueprintID) &&
-                    userWhitelisted(_blueprintID, uint256(_whitelistedQuantity), proof)),
+            // Must be presale and a whitelisted user
+            (_isBlueprintPreparedAndNotStarted(_blueprintID) && proof.length != 0 && _verify(_leaf(msg.sender, uint256(_whitelistedQuantity)), blueprints[_blueprintID].merkleroot, proof)),
             "not available to purchase"
         );
         _;
@@ -198,16 +198,6 @@ contract BlueprintV12 is
         return blueprints[_blueprintID].saleState == SaleState.not_started;
     }
 
-    function userWhitelisted(
-        uint256 _blueprintID,
-        uint256 _quantity,
-        bytes32[] calldata proof
-    ) internal view returns (bool) {
-        require(proof.length != 0, "no proof provided");
-        bytes32 _merkleroot = blueprints[_blueprintID].merkleroot;
-        return _verify(_leaf(msg.sender, _quantity), _merkleroot, proof);
-    }
-
     function feeArrayDataValid(
         address[] memory _feeRecipients,
         uint32[] memory _feeBPS
@@ -217,7 +207,7 @@ contract BlueprintV12 is
             "mismatched recipients & Bps"
         );
         uint32 totalPercent;
-        for (uint256 i = 0; i < _feeBPS.length; i++) {
+        for (uint256 i; i < _feeBPS.length; i++) {
             totalPercent = totalPercent + _feeBPS[i];
         }
         require(totalPercent <= 10000, "Fee Bps > maximum");
@@ -498,7 +488,7 @@ contract BlueprintV12 is
     function _mintQuantity(uint256 _blueprintID, uint32 _quantity, address _nftRecipient) private {
         uint128 newTokenId = blueprints[_blueprintID].erc721TokenIndex;
         uint64 newCap = blueprints[_blueprintID].capacity;
-        for (uint16 i = 0; i < _quantity; i++) {
+        for (uint16 i; i < _quantity; i++) {
             require(newCap > 0, "quantity > cap");
             
             _mint(_nftRecipient, newTokenId + i);
@@ -623,7 +613,7 @@ contract BlueprintV12 is
     {
         require(
             _exists(tokenId),
-            "ERC721Metadata: URI query for nonexistent token"
+            "URI query for nonexistent token"
         );
 
         string memory baseURI = blueprints[tokenToBlueprintID[tokenId]].baseTokenUri;
@@ -719,7 +709,7 @@ contract BlueprintV12 is
         uint32[] memory _primaryFeeBPS = getPrimaryFeeBps(_blueprintID);
         uint256 feesPaid;
 
-        for (uint256 i = 0; i < _primaryFeeRecipients.length; i++) {
+        for (uint256 i; i < _primaryFeeRecipients.length; i++) {
             uint256 fee = (_amount * _primaryFeeBPS[i])/10000;
             feesPaid = feesPaid + fee;
             _payout(_primaryFeeRecipients[i], _erc20Token, fee);
@@ -853,8 +843,8 @@ contract BlueprintV12 is
         )
         returns (bool)
     {
-        // console.log(type(HasSecondarySaleFees).interfaceId);
         return
+            interfaceId == type(HasSecondarySaleFees).interfaceId ||
             ERC721Upgradeable.supportsInterface(interfaceId) ||
             ERC165StorageUpgradeable.supportsInterface(interfaceId) ||
             AccessControlEnumerableUpgradeable.supportsInterface(interfaceId);

--- a/test/artistmint-tests.js
+++ b/test/artistmint-tests.js
@@ -17,8 +17,8 @@ const emptyFeeRecipients = {
   primaryFeeRecipients: [],
   secondaryFeeRecipients: []
 }
-const testPlatformPreSaleMintQuantity = 15;
-const testArtistPreSaleMintQuantity = 17;
+const testPlatformArtistMintQuantity = 15;
+const testArtistArtistMintQuantity = 17;
 const testMaxPurchaseAmount = 0;
 
 function hashToken(account, quantity) {
@@ -69,8 +69,8 @@ describe("Blueprint presale minting", function () {
           testHash,
           testUri,
           this.merkleTree.getHexRoot(),
-          testArtistPreSaleMintQuantity,
-          testPlatformPreSaleMintQuantity,
+          testArtistArtistMintQuantity,
+          testPlatformArtistMintQuantity,
           testMaxPurchaseAmount,
           0,
           feeRecipients
@@ -79,73 +79,73 @@ describe("Blueprint presale minting", function () {
     it("1: Should allow the platform to mint presale", async function () {
       await blueprint
         .connect(ContractOwner)
-        .preSaleMint(0, testPlatformPreSaleMintQuantity);
+        .artistMint(0, testPlatformArtistMintQuantity);
       let result = await blueprint.blueprints(0);
-      let expectedCap = oneThousandPieces - testPlatformPreSaleMintQuantity;
+      let expectedCap = oneThousandPieces - testPlatformArtistMintQuantity;
       expect(result.capacity.toString()).to.be.equal(
         BigNumber.from(expectedCap).toString()
       );
       //should end on the next index
       //this user owns 0 - 9, next user will own 10 - x
       expect(result.erc721TokenIndex.toString()).to.be.equal(
-        BigNumber.from(testPlatformPreSaleMintQuantity).toString()
+        BigNumber.from(testPlatformArtistMintQuantity).toString()
       );
       let platformBalance = await blueprint.balanceOf(ContractOwner.address);
-      expect(platformBalance).to.be.equal(testPlatformPreSaleMintQuantity);
+      expect(platformBalance).to.be.equal(testPlatformArtistMintQuantity);
     });
     it("2: Should allow the artist to mint presale", async function () {
       await blueprint
         .connect(testArtist)
-        .preSaleMint(0, testArtistPreSaleMintQuantity);
+        .artistMint(0, testArtistArtistMintQuantity);
       let result = await blueprint.blueprints(0);
-      let expectedCap = oneThousandPieces - testArtistPreSaleMintQuantity;
+      let expectedCap = oneThousandPieces - testArtistArtistMintQuantity;
       expect(result.capacity.toString()).to.be.equal(
         BigNumber.from(expectedCap).toString()
       );
       //should end on the next index
       //this user owns 0 - 9, next user will own 10 - x
       expect(result.erc721TokenIndex.toString()).to.be.equal(
-        BigNumber.from(testArtistPreSaleMintQuantity).toString()
+        BigNumber.from(testArtistArtistMintQuantity).toString()
       );
       let platformBalance = await blueprint.balanceOf(testArtist.address);
-      expect(platformBalance).to.be.equal(testArtistPreSaleMintQuantity);
+      expect(platformBalance).to.be.equal(testArtistArtistMintQuantity);
     });
     it("3: Should not allow the platform to mint more than allocation", async function () {
       await expect(
         blueprint
           .connect(ContractOwner)
-          .preSaleMint(0, testPlatformPreSaleMintQuantity + 1)
+          .artistMint(0, testPlatformArtistMintQuantity + 1)
       ).to.be.revertedWith("cannot mint quantity");
     });
     it("4: Should not allow the artist to mint more than allocation", async function () {
       await expect(
         blueprint
           .connect(testArtist)
-          .preSaleMint(0, testArtistPreSaleMintQuantity + 1)
+          .artistMint(0, testArtistArtistMintQuantity + 1)
       ).to.be.revertedWith("cannot mint quantity");
     });
     it("5: Should not allow other user to mint preSale", async function () {
       await expect(
-        blueprint.connect(user1).preSaleMint(0, testArtistPreSaleMintQuantity)
+        blueprint.connect(user1).artistMint(0, testArtistArtistMintQuantity)
       ).to.be.revertedWith("user cannot mint presale");
     });
     it("6: Should allow presale mint once sale started", async function () {
       await blueprint.connect(ContractOwner).beginSale(0);
       await blueprint
           .connect(testArtist)
-          .preSaleMint(0, testArtistPreSaleMintQuantity);
+          .artistMint(0, testArtistArtistMintQuantity);
       let result = await blueprint.blueprints(0);
-      let expectedCap = oneThousandPieces - testArtistPreSaleMintQuantity;
+      let expectedCap = oneThousandPieces - testArtistArtistMintQuantity;
       expect(result.capacity.toString()).to.be.equal(
         BigNumber.from(expectedCap).toString()
       );
       //should end on the next index
       //this user owns 0 - 9, next user will own 10 - x
       expect(result.erc721TokenIndex.toString()).to.be.equal(
-        BigNumber.from(testArtistPreSaleMintQuantity).toString()
+        BigNumber.from(testArtistArtistMintQuantity).toString()
       );
       let platformBalance = await blueprint.balanceOf(testArtist.address);
-      expect(platformBalance).to.be.equal(testArtistPreSaleMintQuantity);
+      expect(platformBalance).to.be.equal(testArtistArtistMintQuantity);
     });
     it("7: Should not allow presale mint when sale paused", async function () {
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -153,7 +153,7 @@ describe("Blueprint presale minting", function () {
       await expect(
         blueprint
           .connect(testArtist)
-          .preSaleMint(0, testArtistPreSaleMintQuantity)
+          .artistMint(0, testArtistArtistMintQuantity)
       ).to.be.revertedWith("Must be presale or public sale");
     });
   });

--- a/test/interface-tests.js
+++ b/test/interface-tests.js
@@ -1,0 +1,20 @@
+const { expect } = require("chai");
+
+describe("Admin Blueprint Tests", function () {
+  let Blueprint;
+  let blueprint;
+
+  beforeEach(async function () {
+    [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
+      await ethers.getSigners();
+
+    Blueprint = await ethers.getContractFactory("BlueprintV12");
+    blueprint = await Blueprint.deploy();
+    blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address);
+  });
+  it("supports HasSecondarySaleFees interface", async function () {
+    // This interfaceId is different than the _INTERFACE_ID_FEES that HasSecondarySaleFees registers with ERC165 but it matches its type(HasSecondarySaleFees).interfaceId which is what we really care about
+    let supports = await blueprint.connect(ContractOwner).supportsInterface(0x37d7db38);
+    expect(supports).to.be.equal(true);
+  });
+});

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -133,7 +133,7 @@ describe("Merkleroot Tests", function () {
         blueprint
           .connect(user3)
           .purchaseBlueprints(0, 1, 1, 0, proof, { value: oneEth })
-      ).to.be.revertedWith("no proof provided");
+      ).to.be.revertedWith("not available to purchase");
     });
     let capacity = tenThousandPieces;
     let index = BigNumber.from(0);


### PR DESCRIPTION
- We did not support HasSecondarySaleFees because the `_registerInterface` call that it makes does not match the value of `type(HasSecondarySaleFees).interfaceId`, we now have a custom check for this in the supportsInterface function
- Some size reduction/gas optimizations

**All of the global blueprints contract changes are in after this PR, BUT we are over size! By ~*156 bytes*. We've already shrank the error messages a decent amount (unless we want to go to error codes), and internal functions that are only used once are inlined. @beshup thoughts on size reduction strategies here?