### PR TITLE
royalties, components C+D

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -54,6 +54,7 @@ contract BlueprintV12 is
         uint32[] primaryFeeBPS;
         address[] primaryFeeRecipients;
         SecondaryFeesInput secondaryFeesInput;
+        bool deploySplit; 
     } 
 
     struct Fees {
@@ -370,7 +371,7 @@ contract BlueprintV12 is
         );
 
         // if pre-existing split isn't passed in, deploy it and set it. 
-        if (feeRecipientInfo.royaltyRecipient == address(0)) {
+        if (_feesInput.deploySplit) {
             feeRecipientInfo.royaltyRecipient = ISplitMain(_splitMain).createSplit(
                 secondaryFeesInput.secondaryFeeRecipients, 
                 secondaryFeesInput.secondaryFeeMPS, 

--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.4;
 
 import "./abstract/HasSecondarySaleFees.sol";
+import "./royalties/interfaces/ISplitMain.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -25,6 +26,8 @@ contract BlueprintV12 is
     address public asyncSaleFeesRecipient;
     address public platform;
     address public minterAddress;
+
+    address private _splitMain;
     
     mapping(uint256 => uint256) tokenToBlueprintID;
     mapping(address => uint256) failedTransferCredits;
@@ -39,11 +42,25 @@ contract BlueprintV12 is
         paused
     }
 
-    struct Fees {
+    struct SecondaryFeesInput {
+        address[] secondaryFeeRecipients; 
+        uint32[] secondaryFeeMPS; // where 100% = 1000000 as per SplitMain
+        uint32 totalRoyaltyCutBPS;
+        address royaltyRecipient; // if this is set, it is used as the de-facto alternative to secondaryFeeRecipients and secondaryFeeBPS
+    }
+
+    // used to bypass stack depth error
+    struct FeesInput {
         uint32[] primaryFeeBPS;
-        uint32[] secondaryFeeBPS;
         address[] primaryFeeRecipients;
-        address[] secondaryFeeRecipients;
+        SecondaryFeesInput secondaryFeesInput;
+    } 
+
+    struct Fees {
+        address[] primaryFeeRecipients;
+        uint32[] primaryFeeBPS;
+        address royaltyRecipient;
+        uint32 totalRoyaltyCutBPS;
     }
 
     struct Blueprints {
@@ -154,7 +171,8 @@ contract BlueprintV12 is
         string memory name_,
         string memory symbol_,
         address minter,
-        address _platform
+        address _platform,
+        address splitMain
     ) public initializer {
         // Intialize parent contracts
         ERC721Upgradeable.__ERC721_init(name_, symbol_);
@@ -173,6 +191,7 @@ contract BlueprintV12 is
         defaultPlatformSecondarySalePercentage = 250; // 2.5%
 
         asyncSaleFeesRecipient = _platform;
+        _splitMain = splitMain;
     }
 
     function _isSaleOngoing(uint256 _blueprintID)
@@ -285,7 +304,7 @@ contract BlueprintV12 is
         uint32 _mintAmountPlatform,
         uint64 _maxPurchaseAmount,
         uint128 _saleEndTimestamp,
-        Fees memory _feeRecipientInfo
+        FeesInput memory feesInput
     )   external 
         onlyRole(MINTER_ROLE)
     {
@@ -303,10 +322,10 @@ contract BlueprintV12 is
             _mintAmountPlatform,
             _maxPurchaseAmount,
             _saleEndTimestamp
-        );
+        ); 
 
         setBlueprintPrepared(_blueprintID, _blueprintMetaData);
-        setFeeRecipients(_blueprintID, _feeRecipientInfo);
+        setFeeRecipients(_blueprintID, feesInput);
     }
 
     function updateBlueprintArtist (
@@ -330,16 +349,37 @@ contract BlueprintV12 is
 
     function setFeeRecipients(
         uint256 _blueprintID,
-        Fees memory _feeRecipientInfo
+        FeesInput memory _feesInput
     ) public onlyRole(MINTER_ROLE) {
         require(
             blueprints[_blueprintID].saleState != SaleState.not_prepared,
             "never prepared"
         );
-        if (feeArrayDataValid(_feeRecipientInfo.primaryFeeRecipients, _feeRecipientInfo.primaryFeeBPS) && 
-                feeArrayDataValid(_feeRecipientInfo.secondaryFeeRecipients, _feeRecipientInfo.secondaryFeeBPS)) {
-            blueprints[_blueprintID].feeRecipientInfo = _feeRecipientInfo;
-        }
+        require(
+            feeArrayDataValid(_feesInput.primaryFeeRecipients, _feesInput.primaryFeeBPS),
+            "invalid primary data"
+        ); 
+
+        SecondaryFeesInput memory secondaryFeesInput = _feesInput.secondaryFeesInput;
+
+        Fees memory feeRecipientInfo = Fees(
+            _feesInput.primaryFeeRecipients,
+            _feesInput.primaryFeeBPS,
+            secondaryFeesInput.royaltyRecipient, 
+            secondaryFeesInput.totalRoyaltyCutBPS
+        );
+
+        // if pre-existing split isn't passed in, deploy it and set it. 
+        if (feeRecipientInfo.royaltyRecipient == address(0)) {
+            feeRecipientInfo.royaltyRecipient = ISplitMain(_splitMain).createSplit(
+                secondaryFeesInput.secondaryFeeRecipients, 
+                secondaryFeesInput.secondaryFeeMPS, 
+                0, 
+                address(0) // immutable split
+            );
+        } 
+        
+        blueprints[_blueprintID].feeRecipientInfo = feeRecipientInfo;
     }
 
     function beginSale(uint256 blueprintID)
@@ -790,15 +830,8 @@ contract BlueprintV12 is
         override
         returns (address[] memory)
     {
-        if (blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.secondaryFeeRecipients.length == 0) {
-            address[] memory feeRecipients = new address[](2);
-            feeRecipients[0] = (asyncSaleFeesRecipient);
-            feeRecipients[1] = (blueprints[tokenToBlueprintID[tokenId]].artist);
-
-            return feeRecipients;
-        } else {
-            return blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.secondaryFeeRecipients;
-        }
+        address[] memory feeRecipients = new address[](1);
+        feeRecipients[0] = blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.royaltyRecipient;
     }
 
     function getFeeBps(uint256 tokenId)
@@ -807,15 +840,8 @@ contract BlueprintV12 is
         override
         returns (uint32[] memory)
     {
-        if (blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.secondaryFeeBPS.length == 0) {
-            uint32[] memory feeBPS = new uint32[](2);
-            feeBPS[0] = defaultPlatformSecondarySalePercentage;
-            feeBPS[1] = defaultBlueprintSecondarySalePercentage;
-
-            return feeBPS;
-        } else {
-            return blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.secondaryFeeBPS;
-        }
+        uint32[] memory feeBPS  = new uint32[](1);
+        feeBPS[0] = blueprints[tokenToBlueprintID[tokenId]].feeRecipientInfo.totalRoyaltyCutBPS;
     }
 
     ////////////////////////////////////

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -184,7 +184,8 @@ contract CreatorBlueprints is
     function initialize(
         CreatorBlueprintsInput calldata creatorBlueprintsInput,
         CreatorBlueprintsAdmins calldata creatorBlueprintsAdmins,
-        RoyaltyParameters calldata _royaltyParameters
+        RoyaltyParameters calldata _royaltyParameters,
+        address extraMinter
     ) public initializer validRoyaltyParameters(_royaltyParameters) {
         // Intialize parent contracts
         ERC721Upgradeable.__ERC721_init(creatorBlueprintsInput.name, creatorBlueprintsInput.symbol);
@@ -193,6 +194,9 @@ contract CreatorBlueprints is
 
         _setupRole(DEFAULT_ADMIN_ROLE, creatorBlueprintsAdmins.platform);
         _setupRole(MINTER_ROLE, creatorBlueprintsAdmins.minter);
+        if (extraMinter != address(0)) {
+            _setupRole(MINTER_ROLE, extraMinter);
+        }
 
         platform = creatorBlueprintsAdmins.platform;
         minterAddress = creatorBlueprintsAdmins.minter;

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -65,6 +65,19 @@ contract CreatorBlueprints is
         Fees feeRecipientInfo;
     }
 
+    struct BlueprintPreparationConfig {
+        uint64 _capacity;
+        uint128 _price;
+        address _erc20Token;
+        string _blueprintMetaData;
+        string _baseTokenUri;
+        bytes32 _merkleroot;
+        uint32 _mintAmountArtist;
+        uint32 _mintAmountPlatform;
+        uint64 _maxPurchaseAmount;
+        uint128 _saleEndTimestamp;
+        Fees _feeRecipientInfo; 
+    }
     struct CreatorBlueprintsInput {
         string name;
         string symbol;
@@ -287,35 +300,25 @@ contract CreatorBlueprints is
     }
 
     function prepareBlueprint(
-        uint64 _capacity,
-        uint128 _price,
-        address _erc20Token,
-        string memory _blueprintMetaData,
-        string memory _baseTokenUri,
-        bytes32 _merkleroot,
-        uint32 _mintAmountArtist,
-        uint32 _mintAmountPlatform,
-        uint64 _maxPurchaseAmount,
-        uint128 _saleEndTimestamp,
-        Fees memory _feeRecipientInfo
+        BlueprintPreparationConfig calldata config
     )   external 
         onlyRole(MINTER_ROLE)
     {
-        blueprint.capacity = _capacity;
-        blueprint.price = _price;
+        blueprint.capacity = config._capacity;
+        blueprint.price = config._price;
 
         _setupBlueprint(
-            _erc20Token,
-            _baseTokenUri,
-            _merkleroot,
-            _mintAmountArtist,
-            _mintAmountPlatform,
-            _maxPurchaseAmount,
-            _saleEndTimestamp
+            config._erc20Token,
+            config._baseTokenUri,
+            config._merkleroot,
+            config._mintAmountArtist,
+            config._mintAmountPlatform,
+            config._maxPurchaseAmount,
+            config._saleEndTimestamp
         );
 
-        setBlueprintPrepared(_blueprintMetaData);
-        setFeeRecipients(_feeRecipientInfo);
+        setBlueprintPrepared(config._blueprintMetaData);
+        setFeeRecipients(config._feeRecipientInfo);
     }
 
     function updateBlueprintArtist (

--- a/contracts/contracts/README.md
+++ b/contracts/contracts/README.md
@@ -1,0 +1,7 @@
+# CreatorBlueprints
+
+`CreatorBlueprints` is a creator-deployed Blueprints contract supporting one Blueprint. 
+
+### Setting royalties
+
+Royalties on each Blueprints are handled by it's corresponding royalty split address and total royalty cut. The total royalty cut defines the amount of the token sale that is sent to the splits contract. The holder of the `MINTER_ROLE` can modify both the recipient address and total royalty cut via `changeRoyaltyParameters`. To modify the actual split itself, do so directly on `SplitMain` (https://docs.0xsplits.xyz/smartcontracts/overview#addresses).

--- a/contracts/contracts/deployment/BlueprintsFactory.sol
+++ b/contracts/contracts/deployment/BlueprintsFactory.sol
@@ -56,7 +56,8 @@ contract BlueprintsFactory is Ownable {
                 globalBlueprintsName,
                 globalBlueprintsSymbol,
                 globalBlueprintsMinter,
-                _platform           
+                _platform,
+                splitMain           
             )
         ));
 

--- a/contracts/contracts/deployment/README.md
+++ b/contracts/contracts/deployment/README.md
@@ -29,3 +29,7 @@ Async should use `predictBlueprintsRoyaltiesSplitAddress` to predict the split a
 ### System smart contracts 
 
 When the factory is deployed, it also deploys the `CreatorBlueprints` implementation, it's beacon, the global `BlueprintsV12` implementation, and it's proxy. These 4 smart contracts encapsulate Async's Blueprints ecosystem, meaning only the factory deployment is required to get started. 
+
+### Default platform address 
+
+The factory contains default platform and minter addresses, which are passed in on each `CreatorBlueprints` deployment. These can be changed by the owner of the factory contract. They are initially set in the `initalize` of the factory. When you do want to change either one or both, (eg. one of them is compromised), call `changeDefaultCreatorBlueprintsAdmins`.

--- a/contracts/contracts/deployment/README.md
+++ b/contracts/contracts/deployment/README.md
@@ -1,0 +1,31 @@
+# Usage
+
+`BlueprintsFactory` is used to setup the smart contracts a creator needs to distribute Blueprints NFTs, and collect royalties from them. There are currently two configurations on the factory. 
+1. Deploy creator blueprints contract, and deploy a `0xSplits` (https://www.0xsplits.xyz/) compliant royalty splitter contract. 
+2. Deploy creator blueprints contract, pass in pre-existing royalty split address. 
+
+### 0xSplits Usage 
+`0xSplits` uses the Create2 opcode to deterministically deploy a royalty split contract depending on these three inputs:
+1. `address[] calldata accounts`
+2. `uint32[] calldata percentAllocations`
+3. `uint32 distributorFee` 
+
+### Contract address clashing 
+`BlueprintsFactory` takes the first two as arguments, and automatically sets the `distributorFee` to 0 when deploying a royalty split contract
+prior to deploying the associated creator Blueprints contract. Since the royalty split address is deterministic, once a split is deployed with 
+a set of inputs on a network, one cannot deploy another split with the same arguments on the same network, as the contract addresses would clash. 
+An alternative solution is to slightly modify the `0xSplits` `SplitMain` contract to take in a nonce on split creation that Async can modulate to ensure this never happens.
+An example can be found here: https://github.com/highlightxyz/hl-contracts/blob/main/contracts/royalties/SplitMain.sol. This would require a separate instance of `SplitMain` deployed.
+We've avoided this solution for now. 
+
+2 solutions are proposed for situations requiring a split with the same inputs as a previous split. 
+1. If a royalty split address exists for a set of inputs already, simply use the alternative deploy function on the factory, `deployCreatorBlueprints`, passing in the existing split address. 
+2. If the above solution doesn't work (if we require a completely separate contract initially for the split), create a split on the `SplitMain` contract directly, passing in a random distributor fee, and then change the distributor fee back to 0 in a subsequent transaction. 
+
+### Opensea royalty interoperabilty 
+
+Async should use `predictBlueprintsRoyaltiesSplitAddress` to predict the split address prior to deploying a creator's blueprints contract. This serves well to identify clashes as per the above section. More importantly, it can be used to populate contract-level metadata for the creator blueprints contract. Opensea automatically configures royalty recipients for a collection if they are specified in contract-level metadata, exposed through the function `contractURI` (https://docs.opensea.io/docs/contract-level-metadata). Since this string is passed in on deployment, it is important that Async knows the expected split address before deployment. 
+
+### System smart contracts 
+
+When the factory is deployed, it also deploys the `CreatorBlueprints` implementation, it's beacon, the global `BlueprintsV12` implementation, and it's proxy. These 4 smart contracts encapsulate Async's Blueprints ecosystem, meaning only the factory deployment is required to get started. 

--- a/contracts/contracts/royalties/SplitMain.sol
+++ b/contracts/contracts/royalties/SplitMain.sol
@@ -1,0 +1,845 @@
+
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {ISplitMain} from './interfaces/ISplitMain.sol';
+import {SplitWallet} from './SplitWallet.sol';
+import {Clones} from './libraries/Clones.sol';
+import {ERC20} from '@rari-capital/solmate/src/tokens/ERC20.sol';
+import {SafeTransferLib} from '@rari-capital/solmate/src/utils/SafeTransferLib.sol';
+
+/**
+                                             █████████
+                                          ███████████████                  █████████
+                                         █████████████████               █████████████                 ███████
+                                        ███████████████████             ███████████████               █████████
+                                        ███████████████████             ███████████████              ███████████
+                                        ███████████████████             ███████████████               █████████
+                                         █████████████████               █████████████                 ███████
+                                          ███████████████                  █████████
+                                             █████████
+                             ███████████
+                          █████████████████                 █████████
+                         ███████████████████             ███████████████                  █████████
+                        █████████████████████           █████████████████               █████████████                ███████
+                       ███████████████████████         ███████████████████             ███████████████              █████████
+                       ███████████████████████         ███████████████████             ███████████████             ███████████
+                       ███████████████████████         ███████████████████             ███████████████              █████████
+                        █████████████████████           █████████████████               █████████████                ███████
+                         ███████████████████              █████████████                   █████████
+                          █████████████████                 █████████
+                             ███████████
+           ███████████
+       ███████████████████                  ███████████
+     ███████████████████████              ███████████████                  █████████
+    █████████████████████████           ███████████████████             ███████████████               █████████
+   ███████████████████████████         █████████████████████           █████████████████            █████████████              ███████
+   ███████████████████████████        ███████████████████████         ███████████████████          ███████████████            █████████
+   ███████████████████████████        ███████████████████████         ███████████████████          ███████████████           ███████████
+   ███████████████████████████        ███████████████████████         ███████████████████          ███████████████            █████████
+   ███████████████████████████         █████████████████████           █████████████████            █████████████              ███████
+    █████████████████████████           ███████████████████              █████████████                █████████
+      █████████████████████               ███████████████                  █████████
+        █████████████████                   ███████████
+           ███████████
+                             ███████████
+                          █████████████████                 █████████
+                         ███████████████████             ███████████████                  █████████
+                        █████████████████████           █████████████████               █████████████                ███████
+                       ███████████████████████         ███████████████████             ███████████████              █████████
+                       ███████████████████████         ███████████████████             ███████████████             ███████████
+                       ███████████████████████         ███████████████████             ███████████████              █████████
+                        █████████████████████           █████████████████               █████████████                ███████
+                         ███████████████████              █████████████                   █████████
+                          █████████████████                 █████████
+                             ███████████
+                                             █████████
+                                          ███████████████                  █████████
+                                         █████████████████               █████████████                 ███████
+                                        ███████████████████             ███████████████               █████████
+                                        ███████████████████             ███████████████              ███████████
+                                        ███████████████████             ███████████████               █████████
+                                         █████████████████               █████████████                 ███████
+                                          ███████████████                  █████████
+                                             █████████
+ */
+
+/**
+ * ERRORS
+ */
+
+/// @notice Unauthorized sender `sender`
+/// @param sender Transaction sender
+error Unauthorized(address sender);
+/// @notice Invalid number of accounts `accountsLength`, must have at least 2
+/// @param accountsLength Length of accounts array
+error InvalidSplit__TooFewAccounts(uint256 accountsLength);
+/// @notice Array lengths of accounts & percentAllocations don't match (`accountsLength` != `allocationsLength`)
+/// @param accountsLength Length of accounts array
+/// @param allocationsLength Length of percentAllocations array
+error InvalidSplit__AccountsAndAllocationsMismatch(
+  uint256 accountsLength,
+  uint256 allocationsLength
+);
+/// @notice Invalid percentAllocations sum `allocationsSum` must equal `PERCENTAGE_SCALE`
+/// @param allocationsSum Sum of percentAllocations array
+error InvalidSplit__InvalidAllocationsSum(uint32 allocationsSum);
+/// @notice Invalid accounts ordering at `index`
+/// @param index Index of out-of-order account
+error InvalidSplit__AccountsOutOfOrder(uint256 index);
+/// @notice Invalid percentAllocation of zero at `index`
+/// @param index Index of zero percentAllocation
+error InvalidSplit__AllocationMustBePositive(uint256 index);
+/// @notice Invalid distributorFee `distributorFee` cannot be greater than 10% (1e5)
+/// @param distributorFee Invalid distributorFee amount
+error InvalidSplit__InvalidDistributorFee(uint32 distributorFee);
+/// @notice Invalid hash `hash` from split data (accounts, percentAllocations, distributorFee)
+/// @param hash Invalid hash
+error InvalidSplit__InvalidHash(bytes32 hash);
+/// @notice Invalid new controlling address `newController` for mutable split
+/// @param newController Invalid new controller
+error InvalidNewController(address newController);
+
+/**
+ * @title SplitMain
+ * @author 0xSplits <will@0xSplits.xyz>
+ * @notice A composable and gas-efficient protocol for deploying splitter contracts.
+ * @dev Split recipients, ownerships, and keeper fees are stored onchain as calldata & re-passed as args / validated
+ * via hashing when needed. Each split gets its own address & proxy for maximum composability with other contracts onchain.
+ * For these proxies, we extended EIP-1167 Minimal Proxy Contract to avoid `DELEGATECALL` inside `receive()` to accept
+ * hard gas-capped `sends` & `transfers`.
+ */
+contract SplitMain is ISplitMain {
+  using SafeTransferLib for address;
+  using SafeTransferLib for ERC20;
+
+  /**
+   * STRUCTS
+   */
+
+  /// @notice holds Split metadata
+  struct Split {
+    bytes32 hash;
+    address controller;
+    address newPotentialController;
+  }
+
+  /**
+   * STORAGE
+   */
+
+  /**
+   * STORAGE - CONSTANTS & IMMUTABLES
+   */
+
+  /// @notice constant to scale uints into percentages (1e6 == 100%)
+  uint256 public constant PERCENTAGE_SCALE = 1e6;
+  /// @notice maximum distributor fee; 1e5 = 10% * PERCENTAGE_SCALE
+  uint256 internal constant MAX_DISTRIBUTOR_FEE = 1e5;
+  /// @notice address of wallet implementation for split proxies
+  address public immutable override walletImplementation;
+
+  /**
+   * STORAGE - VARIABLES - PRIVATE & INTERNAL
+   */
+
+  /// @notice mapping to account ETH balances
+  mapping(address => uint256) internal ethBalances;
+  /// @notice mapping to account ERC20 balances
+  mapping(ERC20 => mapping(address => uint256)) internal erc20Balances;
+  /// @notice mapping to Split metadata
+  mapping(address => Split) internal splits;
+
+  /**
+   * MODIFIERS
+   */
+
+  /** @notice Reverts if the sender doesn't own the split `split`
+   *  @param split Address to check for control
+   */
+  modifier onlySplitController(address split) {
+    if (msg.sender != splits[split].controller) revert Unauthorized(msg.sender);
+    _;
+  }
+
+  /** @notice Reverts if the sender isn't the new potential controller of split `split`
+   *  @param split Address to check for new potential control
+   */
+  modifier onlySplitNewPotentialController(address split) {
+    if (msg.sender != splits[split].newPotentialController)
+      revert Unauthorized(msg.sender);
+    _;
+  }
+
+  /** @notice Reverts if the split with recipients represented by `accounts` and `percentAllocations` is malformed
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   */
+  modifier validSplit(
+    address[] memory accounts,
+    uint32[] memory percentAllocations,
+    uint32 distributorFee
+  ) {
+    if (accounts.length < 2)
+      revert InvalidSplit__TooFewAccounts(accounts.length);
+    if (accounts.length != percentAllocations.length)
+      revert InvalidSplit__AccountsAndAllocationsMismatch(
+        accounts.length,
+        percentAllocations.length
+      );
+    // _getSum should overflow if any percentAllocation[i] < 0
+    if (_getSum(percentAllocations) != PERCENTAGE_SCALE)
+      revert InvalidSplit__InvalidAllocationsSum(_getSum(percentAllocations));
+    unchecked {
+      // overflow should be impossible in for-loop index
+      // cache accounts length to save gas
+      uint256 loopLength = accounts.length - 1;
+      for (uint256 i = 0; i < loopLength; ++i) {
+        // overflow should be impossible in array access math
+        if (accounts[i] >= accounts[i + 1])
+          revert InvalidSplit__AccountsOutOfOrder(i);
+        if (percentAllocations[i] == uint32(0))
+          revert InvalidSplit__AllocationMustBePositive(i);
+      }
+      // overflow should be impossible in array access math with validated equal array lengths
+      if (percentAllocations[loopLength] == uint32(0))
+        revert InvalidSplit__AllocationMustBePositive(loopLength);
+    }
+    if (distributorFee > MAX_DISTRIBUTOR_FEE)
+      revert InvalidSplit__InvalidDistributorFee(distributorFee);
+    _;
+  }
+
+  /** @notice Reverts if `newController` is the zero address
+   *  @param newController Proposed new controlling address
+   */
+  modifier validNewController(address newController) {
+    if (newController == address(0)) revert InvalidNewController(newController);
+    _;
+  }
+
+  /**
+   * CONSTRUCTOR
+   */
+
+  constructor() {
+    walletImplementation = address(new SplitWallet());
+  }
+
+  /**
+   * FUNCTIONS
+   */
+
+  /**
+   * FUNCTIONS - PUBLIC & EXTERNAL
+   */
+
+  /** @notice Receive ETH
+   *  @dev Used by split proxies in `distributeETH` to transfer ETH to `SplitMain`
+   *  Funds sent outside of `distributeETH` will be unrecoverable
+   */
+  receive() external payable {}
+
+  /** @notice Creates a new split with recipients `accounts` with ownerships `percentAllocations`, a keeper fee for splitting of `distributorFee` and the controlling address `controller`
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param controller Controlling address (0x0 if immutable)
+   *  @return split Address of newly created split
+   */
+  function createSplit(
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address controller
+  )
+    external
+    override
+    validSplit(accounts, percentAllocations, distributorFee)
+    returns (address split)
+  {
+    bytes32 splitHash = _hashSplit(
+      accounts,
+      percentAllocations,
+      distributorFee
+    );
+    if (controller == address(0)) {
+      // create immutable split
+      split = Clones.cloneDeterministic(walletImplementation, splitHash);
+    } else {
+      // create mutable split
+      split = Clones.clone(walletImplementation);
+      splits[split].controller = controller;
+    }
+    // store split's hash in storage for future verification
+    splits[split].hash = splitHash;
+    emit CreateSplit(split);
+  }
+
+  /** @notice Predicts the address for an immutable split created with recipients `accounts` with ownerships `percentAllocations` and a keeper fee for splitting of `distributorFee`
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @return split Predicted address of such an immutable split
+   */
+  function predictImmutableSplitAddress(
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee
+  )
+    external
+    view
+    override
+    validSplit(accounts, percentAllocations, distributorFee)
+    returns (address split)
+  {
+    bytes32 splitHash = _hashSplit(
+      accounts,
+      percentAllocations,
+      distributorFee
+    );
+    split = Clones.predictDeterministicAddress(walletImplementation, splitHash);
+  }
+
+  /** @notice Updates an existing split with recipients `accounts` with ownerships `percentAllocations` and a keeper fee for splitting of `distributorFee`
+   *  @param split Address of mutable split to update
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   */
+  function updateSplit(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee
+  )
+    external
+    override
+    onlySplitController(split)
+    validSplit(accounts, percentAllocations, distributorFee)
+  {
+    _updateSplit(split, accounts, percentAllocations, distributorFee);
+  }
+
+  /** @notice Begins transfer of the controlling address of mutable split `split` to `newController`
+   *  @dev Two-step control transfer inspired by [dharma](https://github.com/dharma-eng/dharma-smart-wallet/blob/master/contracts/helpers/TwoStepOwnable.sol)
+   *  @param split Address of mutable split to transfer control for
+   *  @param newController Address to begin transferring control to
+   */
+  function transferControl(address split, address newController)
+    external
+    override
+    onlySplitController(split)
+    validNewController(newController)
+  {
+    splits[split].newPotentialController = newController;
+    emit InitiateControlTransfer(split, newController);
+  }
+
+  /** @notice Cancels transfer of the controlling address of mutable split `split`
+   *  @param split Address of mutable split to cancel control transfer for
+   */
+  function cancelControlTransfer(address split)
+    external
+    override
+    onlySplitController(split)
+  {
+    delete splits[split].newPotentialController;
+    emit CancelControlTransfer(split);
+  }
+
+  /** @notice Accepts transfer of the controlling address of mutable split `split`
+   *  @param split Address of mutable split to accept control transfer for
+   */
+  function acceptControl(address split)
+    external
+    override
+    onlySplitNewPotentialController(split)
+  {
+    delete splits[split].newPotentialController;
+    emit ControlTransfer(split, splits[split].controller, msg.sender);
+    splits[split].controller = msg.sender;
+  }
+
+  /** @notice Turns mutable split `split` immutable
+   *  @param split Address of mutable split to turn immutable
+   */
+  function makeSplitImmutable(address split)
+    external
+    override
+    onlySplitController(split)
+  {
+    delete splits[split].newPotentialController;
+    emit ControlTransfer(split, splits[split].controller, address(0));
+    splits[split].controller = address(0);
+  }
+
+  /** @notice Distributes the ETH balance for split `split`
+   *  @dev `accounts`, `percentAllocations`, and `distributorFee` are verified by hashing
+   *  & comparing to the hash in storage associated with split `split`
+   *  @param split Address of split to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function distributeETH(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external override validSplit(accounts, percentAllocations, distributorFee) {
+    // use internal fn instead of modifier to avoid stack depth compiler errors
+    _validSplitHash(split, accounts, percentAllocations, distributorFee);
+    _distributeETH(
+      split,
+      accounts,
+      percentAllocations,
+      distributorFee,
+      distributorAddress
+    );
+  }
+
+  /** @notice Updates & distributes the ETH balance for split `split`
+   *  @dev only callable by SplitController
+   *  @param split Address of split to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function updateAndDistributeETH(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  )
+    external
+    override
+    onlySplitController(split)
+    validSplit(accounts, percentAllocations, distributorFee)
+  {
+    _updateSplit(split, accounts, percentAllocations, distributorFee);
+    // know splitHash is valid immediately after updating; only accessible via controller
+    _distributeETH(
+      split,
+      accounts,
+      percentAllocations,
+      distributorFee,
+      distributorAddress
+    );
+  }
+
+  /** @notice Distributes the ERC20 `token` balance for split `split`
+   *  @dev `accounts`, `percentAllocations`, and `distributorFee` are verified by hashing
+   *  & comparing to the hash in storage associated with split `split`
+   *  @dev pernicious ERC20s may cause overflow in this function inside
+   *  _scaleAmountByPercentage, but results do not affect ETH & other ERC20 balances
+   *  @param split Address of split to distribute balance for
+   *  @param token Address of ERC20 to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function distributeERC20(
+    address split,
+    ERC20 token,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external override validSplit(accounts, percentAllocations, distributorFee) {
+    // use internal fn instead of modifier to avoid stack depth compiler errors
+    _validSplitHash(split, accounts, percentAllocations, distributorFee);
+    _distributeERC20(
+      split,
+      token,
+      accounts,
+      percentAllocations,
+      distributorFee,
+      distributorAddress
+    );
+  }
+
+  /** @notice Updates & distributes the ERC20 `token` balance for split `split`
+   *  @dev only callable by SplitController
+   *  @dev pernicious ERC20s may cause overflow in this function inside
+   *  _scaleAmountByPercentage, but results do not affect ETH & other ERC20 balances
+   *  @param split Address of split to distribute balance for
+   *  @param token Address of ERC20 to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function updateAndDistributeERC20(
+    address split,
+    ERC20 token,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  )
+    external
+    override
+    onlySplitController(split)
+    validSplit(accounts, percentAllocations, distributorFee)
+  {
+    _updateSplit(split, accounts, percentAllocations, distributorFee);
+    // know splitHash is valid immediately after updating; only accessible via controller
+    _distributeERC20(
+      split,
+      token,
+      accounts,
+      percentAllocations,
+      distributorFee,
+      distributorAddress
+    );
+  }
+
+  /** @notice Withdraw ETH &/ ERC20 balances for account `account`
+   *  @param account Address to withdraw on behalf of
+   *  @param withdrawETH Withdraw all ETH if nonzero
+   *  @param tokens Addresses of ERC20s to withdraw
+   */
+  function withdraw(
+    address account,
+    uint256 withdrawETH,
+    ERC20[] calldata tokens
+  ) external override {
+    uint256[] memory tokenAmounts = new uint256[](tokens.length);
+    uint256 ethAmount;
+    if (withdrawETH != 0) {
+      ethAmount = _withdraw(account);
+    }
+    unchecked {
+      // overflow should be impossible in for-loop index
+      for (uint256 i = 0; i < tokens.length; ++i) {
+        // overflow should be impossible in array length math
+        tokenAmounts[i] = _withdrawERC20(account, tokens[i]);
+      }
+      emit Withdrawal(account, ethAmount, tokens, tokenAmounts);
+    }
+  }
+
+  /**
+   * FUNCTIONS - VIEWS
+   */
+
+  /** @notice Returns the current hash of split `split`
+   *  @param split Split to return hash for
+   *  @return Split's hash
+   */
+  function getHash(address split) external view returns (bytes32) {
+    return splits[split].hash;
+  }
+
+  /** @notice Returns the current controller of split `split`
+   *  @param split Split to return controller for
+   *  @return Split's controller
+   */
+  function getController(address split) external view returns (address) {
+    return splits[split].controller;
+  }
+
+  /** @notice Returns the current newPotentialController of split `split`
+   *  @param split Split to return newPotentialController for
+   *  @return Split's newPotentialController
+   */
+  function getNewPotentialController(address split)
+    external
+    view
+    returns (address)
+  {
+    return splits[split].newPotentialController;
+  }
+
+  /** @notice Returns the current ETH balance of account `account`
+   *  @param account Account to return ETH balance for
+   *  @return Account's balance of ETH
+   */
+  function getETHBalance(address account) external view returns (uint256) {
+    return
+      ethBalances[account] + (splits[account].hash != 0 ? account.balance : 0);
+  }
+
+  /** @notice Returns the ERC20 balance of token `token` for account `account`
+   *  @param account Account to return ERC20 `token` balance for
+   *  @param token Token to return balance for
+   *  @return Account's balance of `token`
+   */
+  function getERC20Balance(address account, ERC20 token)
+    external
+    view
+    returns (uint256)
+  {
+    return
+      erc20Balances[token][account] +
+      (splits[account].hash != 0 ? token.balanceOf(account) : 0);
+  }
+
+  /**
+   * FUNCTIONS - PRIVATE & INTERNAL
+   */
+
+  /** @notice Sums array of uint32s
+   *  @param numbers Array of uint32s to sum
+   *  @return sum Sum of `numbers`.
+   */
+  function _getSum(uint32[] memory numbers) internal pure returns (uint32 sum) {
+    // overflow should be impossible in for-loop index
+    uint256 numbersLength = numbers.length;
+    for (uint256 i = 0; i < numbersLength; ) {
+      sum += numbers[i];
+      unchecked {
+        // overflow should be impossible in for-loop index
+        ++i;
+      }
+    }
+  }
+
+  /** @notice Hashes a split
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @return computedHash Hash of the split.
+   */
+  function _hashSplit(
+    address[] memory accounts,
+    uint32[] memory percentAllocations,
+    uint32 distributorFee
+  ) internal pure returns (bytes32) {
+    return
+      keccak256(abi.encodePacked(accounts, percentAllocations, distributorFee));
+  }
+
+  /** @notice Updates an existing split with recipients `accounts` with ownerships `percentAllocations` and a keeper fee for splitting of `distributorFee`
+   *  @param split Address of mutable split to update
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   */
+  function _updateSplit(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee
+  ) internal {
+    bytes32 splitHash = _hashSplit(
+      accounts,
+      percentAllocations,
+      distributorFee
+    );
+    // store new hash in storage for future verification
+    splits[split].hash = splitHash;
+    emit UpdateSplit(split);
+  }
+
+  /** @notice Checks hash from `accounts`, `percentAllocations`, and `distributorFee` against the hash stored for `split`
+   *  @param split Address of hash to check
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   */
+  function _validSplitHash(
+    address split,
+    address[] memory accounts,
+    uint32[] memory percentAllocations,
+    uint32 distributorFee
+  ) internal view {
+    bytes32 hash = _hashSplit(accounts, percentAllocations, distributorFee);
+    if (splits[split].hash != hash) revert InvalidSplit__InvalidHash(hash);
+  }
+
+  /** @notice Distributes the ETH balance for split `split`
+   *  @dev `accounts`, `percentAllocations`, and `distributorFee` must be verified before calling
+   *  @param split Address of split to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function _distributeETH(
+    address split,
+    address[] memory accounts,
+    uint32[] memory percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) internal {
+    uint256 mainBalance = ethBalances[split];
+    uint256 proxyBalance = split.balance;
+    // if mainBalance is positive, leave 1 in SplitMain for gas efficiency
+    uint256 amountToSplit;
+    unchecked {
+      // underflow should be impossible
+      if (mainBalance > 0) mainBalance -= 1;
+      // overflow should be impossible
+      amountToSplit = mainBalance + proxyBalance;
+    }
+    if (mainBalance > 0) ethBalances[split] = 1;
+    // emit event with gross amountToSplit (before deducting distributorFee)
+    emit DistributeETH(split, amountToSplit, distributorAddress);
+    if (distributorFee != 0) {
+      // given `amountToSplit`, calculate keeper fee
+      uint256 distributorFeeAmount = _scaleAmountByPercentage(
+        amountToSplit,
+        distributorFee
+      );
+      unchecked {
+        // credit keeper with fee
+        // overflow should be impossible with validated distributorFee
+        ethBalances[
+          distributorAddress != address(0) ? distributorAddress : msg.sender
+        ] += distributorFeeAmount;
+        // given keeper fee, calculate how much to distribute to split recipients
+        // underflow should be impossible with validated distributorFee
+        amountToSplit -= distributorFeeAmount;
+      }
+    }
+    unchecked {
+      // distribute remaining balance
+      // overflow should be impossible in for-loop index
+      // cache accounts length to save gas
+      uint256 accountsLength = accounts.length;
+      for (uint256 i = 0; i < accountsLength; ++i) {
+        // overflow should be impossible with validated allocations
+        ethBalances[accounts[i]] += _scaleAmountByPercentage(
+          amountToSplit,
+          percentAllocations[i]
+        );
+      }
+    }
+    // flush proxy ETH balance to SplitMain
+    // split proxy should be guaranteed to exist at this address after validating splitHash
+    // (attacker can't deploy own contract to address with high balance & empty sendETHToMain
+    // to drain ETH from SplitMain)
+    // could technically check if (change in proxy balance == change in SplitMain balance)
+    // before/after external call, but seems like extra gas for no practical benefit
+    if (proxyBalance > 0) SplitWallet(split).sendETHToMain(proxyBalance);
+  }
+
+  /** @notice Distributes the ERC20 `token` balance for split `split`
+   *  @dev `accounts`, `percentAllocations`, and `distributorFee` must be verified before calling
+   *  @dev pernicious ERC20s may cause overflow in this function inside
+   *  _scaleAmountByPercentage, but results do not affect ETH & other ERC20 balances
+   *  @param split Address of split to distribute balance for
+   *  @param token Address of ERC20 to distribute balance for
+   *  @param accounts Ordered, unique list of addresses with ownership in the split
+   *  @param percentAllocations Percent allocations associated with each address
+   *  @param distributorFee Keeper fee paid by split to cover gas costs of distribution
+   *  @param distributorAddress Address to pay `distributorFee` to
+   */
+  function _distributeERC20(
+    address split,
+    ERC20 token,
+    address[] memory accounts,
+    uint32[] memory percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) internal {
+    uint256 amountToSplit;
+    uint256 mainBalance = erc20Balances[token][split];
+    uint256 proxyBalance = token.balanceOf(split);
+    unchecked {
+      // if mainBalance &/ proxyBalance are positive, leave 1 for gas efficiency
+      // underflow should be impossible
+      if (proxyBalance > 0) proxyBalance -= 1;
+      // underflow should be impossible
+      if (mainBalance > 0) {
+        mainBalance -= 1;
+      }
+      // overflow should be impossible
+      amountToSplit = mainBalance + proxyBalance;
+    }
+    if (mainBalance > 0) erc20Balances[token][split] = 1;
+    // emit event with gross amountToSplit (before deducting distributorFee)
+    emit DistributeERC20(split, token, amountToSplit, distributorAddress);
+    if (distributorFee != 0) {
+      // given `amountToSplit`, calculate keeper fee
+      uint256 distributorFeeAmount = _scaleAmountByPercentage(
+        amountToSplit,
+        distributorFee
+      );
+      // overflow should be impossible with validated distributorFee
+      unchecked {
+        // credit keeper with fee
+        erc20Balances[token][
+          distributorAddress != address(0) ? distributorAddress : msg.sender
+        ] += distributorFeeAmount;
+        // given keeper fee, calculate how much to distribute to split recipients
+        amountToSplit -= distributorFeeAmount;
+      }
+    }
+    // distribute remaining balance
+    // overflows should be impossible in for-loop with validated allocations
+    unchecked {
+      // cache accounts length to save gas
+      uint256 accountsLength = accounts.length;
+      for (uint256 i = 0; i < accountsLength; ++i) {
+        erc20Balances[token][accounts[i]] += _scaleAmountByPercentage(
+          amountToSplit,
+          percentAllocations[i]
+        );
+      }
+    }
+    // split proxy should be guaranteed to exist at this address after validating splitHash
+    // (attacker can't deploy own contract to address with high ERC20 balance & empty
+    // sendERC20ToMain to drain ERC20 from SplitMain)
+    // doesn't support rebasing or fee-on-transfer tokens
+    // flush extra proxy ERC20 balance to SplitMain
+    if (proxyBalance > 0)
+      SplitWallet(split).sendERC20ToMain(token, proxyBalance);
+  }
+
+  /** @notice Multiplies an amount by a scaled percentage
+   *  @param amount Amount to get `scaledPercentage` of
+   *  @param scaledPercent Percent scaled by PERCENTAGE_SCALE
+   *  @return scaledAmount Percent of `amount`.
+   */
+  function _scaleAmountByPercentage(uint256 amount, uint256 scaledPercent)
+    internal
+    pure
+    returns (uint256 scaledAmount)
+  {
+    // use assembly to bypass checking for overflow & division by 0
+    // scaledPercent has been validated to be < PERCENTAGE_SCALE)
+    // & PERCENTAGE_SCALE will never be 0
+    // pernicious ERC20s may cause overflow, but results do not affect ETH & other ERC20 balances
+    assembly {
+      /* eg (100 * 2*1e4) / (1e6) */
+      scaledAmount := div(mul(amount, scaledPercent), PERCENTAGE_SCALE)
+    }
+  }
+
+  /** @notice Withdraw ETH for account `account`
+   *  @param account Account to withdrawn ETH for
+   *  @return withdrawn Amount of ETH withdrawn
+   */
+  function _withdraw(address account) internal returns (uint256 withdrawn) {
+    // leave balance of 1 for gas efficiency
+    // underflow if ethBalance is 0
+    withdrawn = ethBalances[account] - 1;
+    ethBalances[account] = 1;
+    account.safeTransferETH(withdrawn);
+  }
+
+  /** @notice Withdraw ERC20 `token` for account `account`
+   *  @param account Account to withdrawn ERC20 `token` for
+   *  @return withdrawn Amount of ERC20 `token` withdrawn
+   */
+  function _withdrawERC20(address account, ERC20 token)
+    internal
+    returns (uint256 withdrawn)
+  {
+    // leave balance of 1 for gas efficiency
+    // underflow if erc20Balance is 0
+    withdrawn = erc20Balances[token][account] - 1;
+    erc20Balances[token][account] = 1;
+    token.safeTransfer(account, withdrawn);
+  }
+}

--- a/contracts/contracts/royalties/SplitWallet.sol
+++ b/contracts/contracts/royalties/SplitWallet.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {ISplitMain} from './interfaces/ISplitMain.sol';
+import {ERC20} from '@rari-capital/solmate/src/tokens/ERC20.sol';
+import {SafeTransferLib} from '@rari-capital/solmate/src/utils/SafeTransferLib.sol';
+
+/**
+ * ERRORS
+ */
+
+/// @notice Unauthorized sender
+error Unauthorized();
+
+/**
+ * @title SplitWallet
+ * @author 0xSplits <will@0xSplits.xyz>
+ * @notice The implementation logic for `SplitProxy`.
+ * @dev `SplitProxy` handles `receive()` itself to avoid the gas cost with `DELEGATECALL`.
+ */
+contract SplitWallet {
+  using SafeTransferLib for address;
+  using SafeTransferLib for ERC20;
+
+  /**
+   * EVENTS
+   */
+
+  /** @notice emitted after each successful ETH transfer to proxy
+   *  @param split Address of the split that received ETH
+   *  @param amount Amount of ETH received
+   */
+  event ReceiveETH(address indexed split, uint256 amount);
+
+  /**
+   * STORAGE
+   */
+
+  /**
+   * STORAGE - CONSTANTS & IMMUTABLES
+   */
+
+  /// @notice address of SplitMain for split distributions & EOA/SC withdrawals
+  ISplitMain public immutable splitMain;
+
+  /**
+   * MODIFIERS
+   */
+
+  /// @notice Reverts if the sender isn't SplitMain
+  modifier onlySplitMain() {
+    if (msg.sender != address(splitMain)) revert Unauthorized();
+    _;
+  }
+
+  /**
+   * CONSTRUCTOR
+   */
+
+  constructor() {
+    splitMain = ISplitMain(msg.sender);
+  }
+
+  /**
+   * FUNCTIONS - PUBLIC & EXTERNAL
+   */
+
+  /** @notice Sends amount `amount` of ETH in proxy to SplitMain
+   *  @dev payable reduces gas cost; no vulnerability to accidentally lock
+   *  ETH introduced since fn call is restricted to SplitMain
+   *  @param amount Amount to send
+   */
+  function sendETHToMain(uint256 amount) external payable onlySplitMain() {
+    address(splitMain).safeTransferETH(amount);
+  }
+
+  /** @notice Sends amount `amount` of ERC20 `token` in proxy to SplitMain
+   *  @dev payable reduces gas cost; no vulnerability to accidentally lock
+   *  ETH introduced since fn call is restricted to SplitMain
+   *  @param token Token to send
+   *  @param amount Amount to send
+   */
+  function sendERC20ToMain(ERC20 token, uint256 amount)
+    external
+    payable
+    onlySplitMain()
+  {
+    token.safeTransfer(address(splitMain), amount);
+  }
+}

--- a/contracts/contracts/royalties/interfaces/ISplitMain.sol
+++ b/contracts/contracts/royalties/interfaces/ISplitMain.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+import {ERC20} from '@rari-capital/solmate/src/tokens/ERC20.sol';
+
+/**
+ * @title ISplitMain
+ * @author 0xSplits <will@0xSplits.xyz>
+ */
+interface ISplitMain {
+  /**
+   * FUNCTIONS
+   */
+
+  function walletImplementation() external returns (address);
+
+  function createSplit(
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address controller
+  ) external returns (address);
+
+  function predictImmutableSplitAddress(
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee
+  ) external view returns (address);
+
+  function updateSplit(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee
+  ) external;
+
+  function transferControl(address split, address newController) external;
+
+  function cancelControlTransfer(address split) external;
+
+  function acceptControl(address split) external;
+
+  function makeSplitImmutable(address split) external;
+
+  function distributeETH(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external;
+
+  function updateAndDistributeETH(
+    address split,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external;
+
+  function distributeERC20(
+    address split,
+    ERC20 token,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external;
+
+  function updateAndDistributeERC20(
+    address split,
+    ERC20 token,
+    address[] calldata accounts,
+    uint32[] calldata percentAllocations,
+    uint32 distributorFee,
+    address distributorAddress
+  ) external;
+
+  function withdraw(
+    address account,
+    uint256 withdrawETH,
+    ERC20[] calldata tokens
+  ) external;
+
+  /**
+   * EVENTS
+   */
+
+  /** @notice emitted after each successful split creation
+   *  @param split Address of the created split
+   */
+  event CreateSplit(address indexed split);
+
+  /** @notice emitted after each successful split update
+   *  @param split Address of the updated split
+   */
+  event UpdateSplit(address indexed split);
+
+  /** @notice emitted after each initiated split control transfer
+   *  @param split Address of the split control transfer was initiated for
+   *  @param newPotentialController Address of the split's new potential controller
+   */
+  event InitiateControlTransfer(
+    address indexed split,
+    address indexed newPotentialController
+  );
+
+  /** @notice emitted after each canceled split control transfer
+   *  @param split Address of the split control transfer was canceled for
+   */
+  event CancelControlTransfer(address indexed split);
+
+  /** @notice emitted after each successful split control transfer
+   *  @param split Address of the split control was transferred for
+   *  @param previousController Address of the split's previous controller
+   *  @param newController Address of the split's new controller
+   */
+  event ControlTransfer(
+    address indexed split,
+    address indexed previousController,
+    address indexed newController
+  );
+
+  /** @notice emitted after each successful ETH balance split
+   *  @param split Address of the split that distributed its balance
+   *  @param amount Amount of ETH distributed
+   *  @param distributorAddress Address to credit distributor fee to
+   */
+  event DistributeETH(
+    address indexed split,
+    uint256 amount,
+    address indexed distributorAddress
+  );
+
+  /** @notice emitted after each successful ERC20 balance split
+   *  @param split Address of the split that distributed its balance
+   *  @param token Address of ERC20 distributed
+   *  @param amount Amount of ERC20 distributed
+   *  @param distributorAddress Address to credit distributor fee to
+   */
+  event DistributeERC20(
+    address indexed split,
+    ERC20 indexed token,
+    uint256 amount,
+    address indexed distributorAddress
+  );
+
+  /** @notice emitted after each successful withdrawal
+   *  @param account Address that funds were withdrawn to
+   *  @param ethAmount Amount of ETH withdrawn
+   *  @param tokens Addresses of ERC20s withdrawn
+   *  @param tokenAmounts Amounts of corresponding ERC20s withdrawn
+   */
+  event Withdrawal(
+    address indexed account,
+    uint256 ethAmount,
+    ERC20[] tokens,
+    uint256[] tokenAmounts
+  );
+}

--- a/contracts/contracts/royalties/libraries/Clones.sol
+++ b/contracts/contracts/royalties/libraries/Clones.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
+
+/// @notice create opcode failed
+error CreateError();
+/// @notice create2 opcode failed
+error Create2Error();
+
+library Clones {
+  /**
+   * @dev Deploys and returns the address of a clone that mimics the behaviour of `implementation`
+   * except when someone calls `receive()` and then it emits an event matching
+   * `SplitWallet.ReceiveETH(indexed address, amount)`
+   * Inspired by OZ & 0age's minimal clone implementations based on eip 1167 found at
+   * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.3.0/contracts/proxy/Clones.sol
+   * and https://medium.com/coinmonks/the-more-minimal-proxy-5756ae08ee48
+   *
+   * This function uses the create2 opcode and a `salt` to deterministically deploy
+   * the clone. Using the same `implementation` and `salt` multiple time will revert, since
+   * the clones cannot be deployed twice at the same address.
+   *
+   * init: 0x3d605d80600a3d3981f3
+   * 3d   returndatasize  0
+   * 605d push1 0x5d      0x5d 0
+   * 80   dup1            0x5d 0x5d 0
+   * 600a push1 0x0a      0x0a 0x5d 0x5d 0
+   * 3d   returndatasize  0 0x0a 0x5d 0x5d 0
+   * 39   codecopy        0x5d 0                      destOffset offset length     memory[destOffset:destOffset+length] = address(this).code[offset:offset+length]       copy executing contracts bytecode
+   * 81   dup2            0 0x5d 0
+   * f3   return          0                           offset length                return memory[offset:offset+length]                                                   returns from this contract call
+   *
+   * contract: 0x36603057343d52307f830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b160203da23d3df35b3d3d3d3d363d3d37363d73bebebebebebebebebebebebebebebebebebebebe5af43d3d93803e605b57fd5bf3
+   *     0x000     36       calldatasize      cds
+   *     0x001     6030     push1 0x30        0x30 cds
+   * ,=< 0x003     57       jumpi
+   * |   0x004     34       callvalue         cv
+   * |   0x005     3d       returndatasize    0 cv
+   * |   0x006     52       mstore
+   * |   0x007     30       address           addr
+   * |   0x008     7f830d.. push32 0x830d..   id addr
+   * |   0x029     6020     push1 0x20        0x20 id addr
+   * |   0x02b     3d       returndatasize    0 0x20 id addr
+   * |   0x02c     a2       log2
+   * |   0x02d     3d       returndatasize    0
+   * |   0x02e     3d       returndatasize    0 0
+   * |   0x02f     f3       return
+   * `-> 0x030     5b       jumpdest
+   *     0x031     3d       returndatasize    0
+   *     0x032     3d       returndatasize    0 0
+   *     0x033     3d       returndatasize    0 0 0
+   *     0x034     3d       returndatasize    0 0 0 0
+   *     0x035     36       calldatasize      cds 0 0 0 0
+   *     0x036     3d       returndatasize    0 cds 0 0 0 0
+   *     0x037     3d       returndatasize    0 0 cds 0 0 0 0
+   *     0x038     37       calldatacopy      0 0 0 0
+   *     0x039     36       calldatasize      cds 0 0 0 0
+   *     0x03a     3d       returndatasize    0 cds 0 0 0 0
+   *     0x03b     73bebe.. push20 0xbebe..   0xbebe 0 cds 0 0 0 0
+   *     0x050     5a       gas               gas 0xbebe 0 cds 0 0 0 0
+   *     0x051     f4       delegatecall      suc 0 0
+   *     0x052     3d       returndatasize    rds suc 0 0
+   *     0x053     3d       returndatasize    rds rds suc 0 0
+   *     0x054     93       swap4             0 rds suc 0 rds
+   *     0x055     80       dup1              0 0 rds suc 0 rds
+   *     0x056     3e       returndatacopy    suc 0 rds
+   *     0x057     605b     push1 0x5b        0x5b suc 0 rds
+   * ,=< 0x059     57       jumpi             0 rds
+   * |   0x05a     fd       revert
+   * `-> 0x05b     5b       jumpdest          0 rds
+   *     0x05c     f3       return
+   *
+   */
+  function clone(address implementation) internal returns (address instance) {
+    assembly {
+      let ptr := mload(0x40)
+      mstore(
+        ptr,
+        0x3d605d80600a3d3981f336603057343d52307f00000000000000000000000000
+      )
+      mstore(
+        add(ptr, 0x13),
+        0x830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b1
+      )
+      mstore(
+        add(ptr, 0x33),
+        0x60203da23d3df35b3d3d3d3d363d3d37363d7300000000000000000000000000
+      )
+      mstore(add(ptr, 0x46), shl(0x60, implementation))
+      mstore(
+        add(ptr, 0x5a),
+        0x5af43d3d93803e605b57fd5bf300000000000000000000000000000000000000
+      )
+      instance := create(0, ptr, 0x67)
+    }
+    if (instance == address(0)) revert CreateError();
+  }
+
+  function cloneDeterministic(address implementation, bytes32 salt)
+    internal
+    returns (address instance)
+  {
+    assembly {
+      let ptr := mload(0x40)
+      mstore(
+        ptr,
+        0x3d605d80600a3d3981f336603057343d52307f00000000000000000000000000
+      )
+      mstore(
+        add(ptr, 0x13),
+        0x830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b1
+      )
+      mstore(
+        add(ptr, 0x33),
+        0x60203da23d3df35b3d3d3d3d363d3d37363d7300000000000000000000000000
+      )
+      mstore(add(ptr, 0x46), shl(0x60, implementation))
+      mstore(
+        add(ptr, 0x5a),
+        0x5af43d3d93803e605b57fd5bf300000000000000000000000000000000000000
+      )
+      instance := create2(0, ptr, 0x67, salt)
+    }
+    if (instance == address(0)) revert Create2Error();
+  }
+
+  /**
+   * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+   */
+  function predictDeterministicAddress(
+    address implementation,
+    bytes32 salt,
+    address deployer
+  ) internal pure returns (address predicted) {
+    assembly {
+      let ptr := mload(0x40)
+      mstore(
+        ptr,
+        0x3d605d80600a3d3981f336603057343d52307f00000000000000000000000000
+      )
+      mstore(
+        add(ptr, 0x13),
+        0x830d2d700a97af574b186c80d40429385d24241565b08a7c559ba283a964d9b1
+      )
+      mstore(
+        add(ptr, 0x33),
+        0x60203da23d3df35b3d3d3d3d363d3d37363d7300000000000000000000000000
+      )
+      mstore(add(ptr, 0x46), shl(0x60, implementation))
+      mstore(
+        add(ptr, 0x5a),
+        0x5af43d3d93803e605b57fd5bf3ff000000000000000000000000000000000000
+      )
+      mstore(add(ptr, 0x68), shl(0x60, deployer))
+      mstore(add(ptr, 0x7c), salt)
+      mstore(add(ptr, 0x9c), keccak256(ptr, 0x67))
+      predicted := keccak256(add(ptr, 0x67), 0x55)
+    }
+  }
+
+  /**
+   * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+   */
+  function predictDeterministicAddress(address implementation, bytes32 salt)
+    internal
+    view
+    returns (address predicted)
+  {
+    return predictDeterministicAddress(implementation, salt, address(this));
+  }
+}

--- a/contracts/deploy/01_DeployContracts.js
+++ b/contracts/deploy/01_DeployContracts.js
@@ -1,20 +1,24 @@
-const { network } = require("hardhat");
+const hre = require("hardhat");
 
-module.exports = async ({ deployments }) => {
-  const { deploy } = deployments;
-  // const { deployer, admin } = await getNamedAccounts();
-  const accounts = await ethers.getSigners();
-  const deployer = accounts[0].address;
-  await deploy("Blueprint", {
-    from: deployer,
-    proxy: {
-      execute: {
-        proxyContract: "UUPSProxy",
-        methodName: "initialize",
-        args: ["Async Blueprint", "ABP"],
-      },
-    },
-    log: true,
-  });
-};
-module.exports.tags = ["all", "contracts"];
+async function main() {
+  const signers = await hre.ethers.getSigners()
+  const BlueprintsFactory = await hre.ethers.getContractFactory("BlueprintsFactory");
+  const blueprintsFactory = await BlueprintsFactory.deploy(
+    signers[0].address,
+    signers[0].address,
+    "name",
+    "symbol",
+    signers[0].address,
+    signers[0].address, 
+    signers[0].address,
+    signers[0].address,
+    signers[0].address
+  );
+
+  await blueprintsFactory.deployed();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,6 +14,9 @@ const {
   coinmarketCapKey,
 } = require("./secretsManager.example.js");
 
+require("./tasks/deploy");
+require("./tasks/factory")
+
 module.exports = {
   solidity: {
     version: "0.8.4",
@@ -31,7 +34,7 @@ module.exports = {
     coinmarketcap: coinmarketCapKey,
   },
   paths: {
-    deploy: "./contracts/deploy",
+    // deploy: "./contracts/deploy",
     deployments: "deployments",
     imports: "imports",
     tests: "./test",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@openzeppelin/contracts": "^4.7.0",
     "@openzeppelin/contracts-upgradeable": "^4.3.2",
     "@openzeppelin/hardhat-upgrades": "^1.10.0",
+    "@rari-capital/solmate": "^6.4.0",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.7",

--- a/tasks/deploy/blueprintsFactory.js
+++ b/tasks/deploy/blueprintsFactory.js
@@ -1,0 +1,30 @@
+const { task } = require("hardhat/config");
+
+task("deploy:blueprintsFactory", "Deploys Blueprints factory")
+  .addParam("beaconUpgrader", "Account that can upgrade creatorBlueprints beacon implementation")
+  .addParam("blueprintV12UpgraderAdmin", "Account that is admin of blueprintV12 upgrade proxy")
+  .addParam("blueprintV12Name", "Name of Blueprintv12 contract")
+  .addParam("blueprintV12Symbol", "Symbol of Blueprintv12 contract")
+  .addParam("blueprintV12Minter", "Permissioned minter for BlueprintV12")
+  .addParam("creatorBlueprintsMinter", "Default permissioned minter for CreatorBlueprints")
+  .addParam("platform", "Default DEFAULT_ADMIN_ROLE / platform address holder for CreatorBlueprints")
+  .addParam("splitMain", "Address of SplitMain royalties contract from 0xSplits")
+  .addParam("factoryOwner", "Owner of deployed factory, able to change default values such as default minter for CreatorBlueprints")
+  .setAction(async (taskArgs, { ethers }) => {
+    const BlueprintsFactory = await ethers.getContractFactory("BlueprintsFactory");
+    const blueprintsFactory = await BlueprintsFactory.deploy(
+        taskArgs.beaconUpgrader,
+        taskArgs.blueprintV12UpgraderAdmin,
+        taskArgs.blueprintV12Name,
+        taskArgs.blueprintV12Symbol,
+        taskArgs.blueprintV12Minter,
+        taskArgs.creatorBlueprintsMinter, 
+        taskArgs.platform,
+        taskArgs.splitMain,
+        taskArgs.factoryOwner
+    );
+
+    await blueprintsFactory.deployed();
+
+    console.log(`Blueprints factory deployed to: ${blueprintsFactory.address}`)
+  });

--- a/tasks/deploy/index.js
+++ b/tasks/deploy/index.js
@@ -1,0 +1,2 @@
+require("./blueprintsFactory");
+require("./splitMain");

--- a/tasks/deploy/splitMain.js
+++ b/tasks/deploy/splitMain.js
@@ -1,0 +1,10 @@
+const { task } = require("hardhat/config");
+
+task("deploy:splitMain", "Deploys SplitMain contract - use on local networks or ones 0xSplits hasn't deployed on")
+  .setAction(async (taskArgs, { ethers }) => {
+    const SplitMain = await ethers.getContractFactory("SplitMain");
+    const splitMain = await SplitMain.deploy();
+
+    await splitMain.deployed();
+    console.log(`SplitMain deployed to ${splitMain.address}`);
+  });

--- a/tasks/factory/deployAndPrepareBlueprintsAndRoyalties.js
+++ b/tasks/factory/deployAndPrepareBlueprintsAndRoyalties.js
@@ -1,0 +1,61 @@
+const { task } = require("hardhat/config");
+
+const BlueprintsFactory = require("../../artifacts/contracts/contracts/deployment/BlueprintsFactory.sol/BlueprintsFactory.json");
+const BlueprintsFactoryABI = BlueprintsFactory.abi; 
+
+task("deployRoyaltySplitterAndPrepareCreatorBlueprints", "Deploys royalty splitter and creator blueprint contract. Does not upload contract metadata. Sets default primary fee values")
+  .addParam("blueprintsFactory", "Blueprints factory address")
+  .addParam("name", "Name of CreatorBlueprints contract")
+  .addParam("symbol", "Symbol of CreatorBlueprints contract")
+  .addParam("contractUri", "URI of contract-level metadata recognized by OpenSea")
+  .addParam("artist", "Address of artist/creator")
+  .addParam("capacity", "Blueprint capacity")
+  .addParam("price", "Blueprint price")
+  .addParam("erc20Token", "Address of erc20Token currency")
+  .addParam("blueprintMetadata", "Metadata uri")
+  .addParam("baseTokenUri", "Blueprint baseTokenUri")
+  .addParam("merkleroot", "Blueprint merkle tree root for allowlist")
+  .addParam("mintAmountArtist", "Maximum artist can mint")
+  .addParam("mintAmountPlatform", "Maximum platform can mint")
+  .addParam("maxPurchaseAmount", "Maximum amount purchasable by user")
+  .addParam("saleEndTimestamp", "Unix timestamp of sale end")
+  .setAction(async (taskArgs, { ethers }) => {
+    const signers = await ethers.getSigners();
+    const blueprintsFactory = new ethers.Contract(taskArgs.blueprintsFactory, BlueprintsFactoryABI, signers[0]); 
+
+    console.log(`Predicted split address to put into metadata: ${await blueprintsFactory.predictBlueprintsRoyaltiesSplitAddress(taskArgs.artist)}`)
+
+    const tx = await blueprintsFactory.deployRoyaltySplitterAndPrepareCreatorBlueprints(
+        [
+            taskArgs.name,
+            taskArgs.symbol,
+            taskArgs.contractUri,
+            taskArgs.artist 
+        ],
+        [
+            taskArgs.capacity,
+            taskArgs.price, 
+            taskArgs.erc20Token,
+            taskArgs.blueprintMetadata,
+            taskArgs.baseTokenUri,
+            taskArgs.merkleroot,
+            taskArgs.mintAmountArtist,
+            taskArgs.mintAmountPlatform,
+            taskArgs.maxPurchaseAmount,
+            taskArgs.saleEndTimestamp,
+            [
+                [],
+                []
+            ]
+        ],
+        1000
+    )
+
+    const txReceipt = await tx.wait(); 
+
+    const iface = new ethers.utils.Interface(BlueprintsFactoryABI);
+    const log = iface.parseLog(txReceipt.logs[5]); 
+    const {creatorBlueprint, royaltySplit} = log.args;
+
+    console.log(`CreatorBlueprints deployed to: ${creatorBlueprint}, corresponding royalty split deployed to: ${royaltySplit}`)
+  });

--- a/tasks/factory/index.js
+++ b/tasks/factory/index.js
@@ -1,0 +1,1 @@
+require("./deployAndPrepareBlueprintsAndRoyalties");

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,11 @@
     proper-lockfile "^4.1.1"
     solidity-ast "^0.4.15"
 
+"@rari-capital/solmate@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@rari-capital/solmate/-/solmate-6.4.0.tgz#c6ee4110c8075f14b415e420b13bd8bdbbc93d9e"
+  integrity sha512-BXWIHHbG5Zbgrxi0qVYe0Zs+bfx+XgOciVUACjuIApV0KzC0kY8XdO1higusIei/ZKCC+GUKdcdQZflxYPUTKQ==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.npmjs.org/@resolver-engine/core/-/core-0.3.3.tgz"


### PR DESCRIPTION
C. Royalty splitter for ETH + ERC20 for Creator blueprints. Fork `0xSplits` protocol, integrate into `BlueprintsFactory` and `CreatorBlueprints`. 

D. Standard impls: EIP-2981, Rarible Royalties V2, Owner + tests. Contract-level metadata (immutable). 

- Royalties (fork of 0xSplits) are integrated into:
   - CreatorBlueprints.sol
   - BlueprintsFactory.sol
- Factory now has an owner, set to a “factoryOwner” value initially, which can modify the default royalty fees and default platform/minter addresses on the factory.
- See for usage / description of behavior: https://github.com/asyncart/async-blueprint/tree/royalties/contracts/contracts/deployment#readme 
- Added function on CreatorBlueprints to set royalty cut and royalty split address, available to DEFAULT_ADMIN_ROLE, to divert attention fully from splitter contract if it’s desired
   - See for how to set royalties on CreatorBlueprints: https://github.com/asyncart/async-blueprint/blob/royalties/contracts/contracts/README.md 
