### PR TITLE
Final edits

### DIFF
--- a/contracts/contracts/common/IBlueprintTypes.sol
+++ b/contracts/contracts/common/IBlueprintTypes.sol
@@ -1,0 +1,56 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.4; 
+
+/**
+ * @dev Interface used to share common types between AsyncArt Blueprints contracts
+ * @author Ohimire Labs
+ */
+interface IBlueprintTypes {
+    /**
+     * @dev Core administrative accounts 
+     * @param platform Platform, holder of DEFAULT_ADMIN role
+     * @param minter Minter, holder of MINTER_ROLE
+     * @param asyncSaleFeesRecipient Recipient of primary sale fees going to platform
+     */
+    struct Admins {
+        address platform;
+        address minter;
+        address asyncSaleFeesRecipient;
+    } 
+
+    /**
+     * @dev Object passed in when preparing blueprint 
+     * @param _capacity Number of NFTs in Blueprint 
+     * @param _price Price per NFT in Blueprint
+     * @param _erc20Token Address of ERC20 currency required to buy NFTs, can be zero address if expected currency is native gas token 
+     * @param _blueprintMetaData Blueprint metadata uri
+     * @param _baseTokenUri Base URI for token, resultant uri for each token is base uri concatenated with token id
+     * @param _merkleroot Root of Merkle tree holding whitelisted accounts 
+     * @param _mintAmountArtist Amount of NFTs of Blueprint mintable by artist
+     * @param _mintAmountPlatform Amount of NFTs of Blueprint mintable by platform 
+     * @param _maxPurchaseAmount Max number of NFTs purchasable in a single transaction
+     * @param _saleEndTimestamp Timestamp when the sale ends 
+     */ 
+    struct BlueprintPreparationConfig {
+        uint64 _capacity;
+        uint128 _price;
+        address _erc20Token;
+        string _blueprintMetaData;
+        string _baseTokenUri;
+        bytes32 _merkleroot;
+        uint32 _mintAmountArtist;
+        uint32 _mintAmountPlatform;
+        uint64 _maxPurchaseAmount;
+        uint128 _saleEndTimestamp;
+    }
+
+    /**
+     * @dev Object holding primary fee data
+     * @param primaryFeeBPS Primary fee percentage allocations, in basis points
+     * @param primaryFeeRecipients Primary fee recipients 
+     */
+    struct PrimaryFees {
+        uint32[] primaryFeeBPS;
+        address[] primaryFeeRecipients;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -8,14 +8,15 @@ require("@openzeppelin/hardhat-upgrades");
 require('hardhat-contract-sizer');
 
 const {
-  rinkebyPrivateKey,
+  goerliPrivateKey,
   alchemyUrl,
   etherscanApiKey,
   coinmarketCapKey,
-} = require("./secretsManager.example.js");
+} = require("./secretsManager.js");
 
 require("./tasks/deploy");
 require("./tasks/factory")
+require("./tasks/royalties");
 
 module.exports = {
   solidity: {
@@ -48,6 +49,10 @@ module.exports = {
     hardhat: {
       allowUnlimitedContractSize: true,
       initialBaseFeePerGas: 0,
+    },
+    goerli: {
+      accounts: [goerliPrivateKey],
+      url: "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
     }
   },
   etherscan: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -8,11 +8,10 @@ require("@openzeppelin/hardhat-upgrades");
 require('hardhat-contract-sizer');
 
 const {
-  goerliPrivateKey,
   alchemyUrl,
   etherscanApiKey,
   coinmarketCapKey,
-} = require("./secretsManager.js");
+} = require("./secretsManager.example.js");
 
 require("./tasks/deploy");
 require("./tasks/factory")
@@ -49,10 +48,6 @@ module.exports = {
     hardhat: {
       allowUnlimitedContractSize: true,
       initialBaseFeePerGas: 0,
-    },
-    goerli: {
-      accounts: [goerliPrivateKey],
-      url: "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
     }
   },
   etherscan: {

--- a/tasks/deploy/blueprintsFactory.js
+++ b/tasks/deploy/blueprintsFactory.js
@@ -1,7 +1,7 @@
 const { task } = require("hardhat/config");
 
 task("deploy:blueprintsFactory", "Deploys Blueprints factory")
-  .addParam("creatorBlueprintUpgrader", "Account that can upgrade CreatorBlueprints beacon implementation")
+  .addParam("creatorBlueprintsUpgrader", "Account that can upgrade CreatorBlueprints beacon implementation")
   .addParam("blueprintV12Upgrader", "Account that can upgrade BlueprintV12 beacon implementation")
   .addParam("blueprintV12Minter", "Permissioned minter for BlueprintV12")
   .addParam("creatorBlueprintsMinter", "Default permissioned minter for CreatorBlueprints")
@@ -11,8 +11,8 @@ task("deploy:blueprintsFactory", "Deploys Blueprints factory")
   .setAction(async (taskArgs, { ethers }) => {
     const BlueprintsFactory = await ethers.getContractFactory("BlueprintsFactory");
     const blueprintsFactory = await BlueprintsFactory.deploy(
-        taskArgs.beaconUpgrader,
-        taskArgs.blueprintV12UpgraderAdmin,
+        taskArgs.creatorBlueprintsUpgrader,
+        taskArgs.blueprintV12Upgrader,
         taskArgs.blueprintV12Minter,
         taskArgs.creatorBlueprintsMinter, 
         taskArgs.platform,

--- a/tasks/deploy/blueprintsFactory.js
+++ b/tasks/deploy/blueprintsFactory.js
@@ -1,10 +1,8 @@
 const { task } = require("hardhat/config");
 
 task("deploy:blueprintsFactory", "Deploys Blueprints factory")
-  .addParam("beaconUpgrader", "Account that can upgrade creatorBlueprints beacon implementation")
-  .addParam("blueprintV12UpgraderAdmin", "Account that is admin of blueprintV12 upgrade proxy")
-  .addParam("blueprintV12Name", "Name of Blueprintv12 contract")
-  .addParam("blueprintV12Symbol", "Symbol of Blueprintv12 contract")
+  .addParam("creatorBlueprintUpgrader", "Account that can upgrade CreatorBlueprints beacon implementation")
+  .addParam("blueprintV12Upgrader", "Account that can upgrade BlueprintV12 beacon implementation")
   .addParam("blueprintV12Minter", "Permissioned minter for BlueprintV12")
   .addParam("creatorBlueprintsMinter", "Default permissioned minter for CreatorBlueprints")
   .addParam("platform", "Default DEFAULT_ADMIN_ROLE / platform address holder for CreatorBlueprints")
@@ -15,8 +13,6 @@ task("deploy:blueprintsFactory", "Deploys Blueprints factory")
     const blueprintsFactory = await BlueprintsFactory.deploy(
         taskArgs.beaconUpgrader,
         taskArgs.blueprintV12UpgraderAdmin,
-        taskArgs.blueprintV12Name,
-        taskArgs.blueprintV12Symbol,
         taskArgs.blueprintV12Minter,
         taskArgs.creatorBlueprintsMinter, 
         taskArgs.platform,

--- a/tasks/factory/deployAndPrepareBlueprintsAndRoyalties.js
+++ b/tasks/factory/deployAndPrepareBlueprintsAndRoyalties.js
@@ -220,15 +220,16 @@ task("deployRoyaltySplitterAndPrepareCreatorBlueprints", "Deploys royalty splitt
             taskArgs.mintAmountArtist,
             taskArgs.mintAmountPlatform,
             taskArgs.maxPurchaseAmount,
-            taskArgs.saleEndTimestamp,
-            [
-                [],
-                []
-            ]
+            taskArgs.saleEndTimestamp
+        ],
+        [
+          [],
+          []
         ],
         sortedAddressArray([platform, taskArgs.artist]),
         [250000, 750000],
-        1000
+        1000,
+        "ID"
     )
 
     const txReceipt = await tx.wait(); 

--- a/tasks/royalties/index.js
+++ b/tasks/royalties/index.js
@@ -1,0 +1,1 @@
+require("./predictSplitAddress");

--- a/tasks/royalties/predictSplitAddress.js
+++ b/tasks/royalties/predictSplitAddress.js
@@ -1,0 +1,47 @@
+const { task } = require("hardhat/config");
+
+const SplitMainABI = [
+    {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "accounts",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint32[]",
+            "name": "percentAllocations",
+            "type": "uint32[]"
+          },
+          {
+            "internalType": "uint32",
+            "name": "distributorFee",
+            "type": "uint32"
+          }
+        ],
+        "name": "predictImmutableSplitAddress",
+        "outputs": [
+          {
+            "internalType": "address",
+            "name": "split",
+            "type": "address"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      }
+]
+
+task("predictSplitAddress", "Predicts royalty split address based on inputs")
+  .addParam("splitMain", "SplitMain address")
+  .addParam("distributorFee", "SplitMain distributor fee")
+ // .addPositionalParam("accounts", "Royalty recipient accounts")
+ // .addPositionalParam("allocations", "Royalty percent allocations")
+  .setAction(async (taskArgs, { ethers }) => {
+    const signers = await ethers.getSigners();
+    const splitMain = new ethers.Contract(taskArgs.splitMain, SplitMainABI, signers[0]);
+    
+    console.log(`Predicted split address: 
+        ${await splitMain.predictImmutableSplitAddress(["0x8Ac794937899956d0402841E620E5C866e9e1097"], [1000000], taskArgs.distributorFee)}
+    `)
+  });

--- a/test/ERC20-tests.js
+++ b/test/ERC20-tests.js
@@ -93,21 +93,23 @@ describe("ERC20 interactions", function () {
 
       await erc20.connect(user1).approve(blueprint.address, oneThousandTokens);
 
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          fiveHundredPieces,
-          oneEth,
-          erc20.address,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          0,
+          [
+            fiveHundredPieces,
+            oneEth,
+            erc20.address,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            0
+          ],
           feesInput
         );
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -138,16 +140,18 @@ describe("ERC20 interactions", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           user2.address,
-          fiveHundredPieces,
-          oneEth,
-          zeroAddress,
-          testHash + "dsfdk",
-          testUri + "unpause_test",
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          0,
+          [
+            fiveHundredPieces,
+            oneEth,
+            zeroAddress,
+            testHash + "dsfdk",
+            testUri + "unpause_test",
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            0
+          ],
           feesInput
         );
       await expect(
@@ -194,7 +198,7 @@ describe("ERC20 interactions", function () {
           blueprint
             .connect(user2)
             .purchaseBlueprints(0, tenPieces, tenPieces, 10, [], { value: 10 })
-        ).to.be.revertedWith("eth value not zero");
+        ).to.be.revertedWith("eth value != 0");
       });
       it("3: should not allow purchase of more than capacity", async function () {
         let fiveHundredEth = fiveHundredPieces.mul(oneEth);

--- a/test/admin-tests.js
+++ b/test/admin-tests.js
@@ -38,7 +38,7 @@ describe("Admin Blueprint Tests", function () {
     blueprint = await Blueprint.deploy();
     SplitMain = await ethers.getContractFactory("SplitMain");
     splitMain = await SplitMain.deploy();
-    blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+    blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
   });
   it("1.a: should update minter role", async function () {
     await blueprint.connect(ContractOwner).updateMinterAddress(user2.address);
@@ -46,16 +46,18 @@ describe("Admin Blueprint Tests", function () {
       .connect(user2)
       .prepareBlueprint(
         testArtist.address,
-        tenThousandPieces,
-        oneEth,
-        zeroAddress,
-        testHash,
-        testUri,
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        0,
-        0,
-        0,
-        0,
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
         feesInput
       );
     let result = await blueprint.blueprints(0);
@@ -74,16 +76,18 @@ describe("Admin Blueprint Tests", function () {
       .connect(ContractOwner)
       .prepareBlueprint(
         testArtist.address,
-        tenThousandPieces,
-        oneEth,
-        zeroAddress,
-        testHash,
-        testUri,
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        0,
-        0,
-        0,
-        0,
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
         feesInput
       );
     let updatedUri = "http://updatedUri/";
@@ -105,16 +109,18 @@ describe("Admin Blueprint Tests", function () {
       .connect(ContractOwner)
       .prepareBlueprint(
         testArtist.address,
-        tenThousandPieces,
-        oneEth,
-        zeroAddress,
-        testHash,
-        testUri,
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        0,
-        0,
-        0,
-        0,
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
         feesInput
       );
     let updatedUri = "http://updatedUri/";
@@ -122,7 +128,7 @@ describe("Admin Blueprint Tests", function () {
     await blueprint.connect(ContractOwner).lockBlueprintTokenUri(0);
     await expect(
       blueprint.connect(ContractOwner).updateBlueprintTokenUri(0, updatedUri)
-    ).to.be.revertedWith("uri locked");
+    ).to.be.revertedWith("locked");
   });
   // it("2.d: should allow platform to update base token uri", async function () {
   //   await blueprint
@@ -156,16 +162,18 @@ describe("Admin Blueprint Tests", function () {
       .connect(ContractOwner)
       .prepareBlueprint(
         testArtist.address,
-        tenThousandPieces,
-        oneEth,
-        zeroAddress,
-        testHash,
-        testUri,
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        0,
-        0,
-        0,
-        0,
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
         feesInput
       );
     let randomSeed = "randomSeedHash";

--- a/test/artistmint-tests.js
+++ b/test/artistmint-tests.js
@@ -69,21 +69,23 @@ describe("Blueprint presale minting", function () {
       blueprint = await Blueprint.deploy();
       SplitMain = await ethers.getContractFactory("SplitMain");
       splitMain = await SplitMain.deploy();
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          oneThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          testArtistArtistMintQuantity,
-          testPlatformArtistMintQuantity,
-          testMaxPurchaseAmount,
-          0,
+          [
+            oneThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            testArtistArtistMintQuantity,
+            testPlatformArtistMintQuantity,
+            testMaxPurchaseAmount,
+            0
+          ],
           feesInput
         );
     });
@@ -126,19 +128,19 @@ describe("Blueprint presale minting", function () {
         blueprint
           .connect(ContractOwner)
           .artistMint(0, testPlatformArtistMintQuantity + 1)
-      ).to.be.revertedWith("can't mint quantity");
+      ).to.be.revertedWith("quantity >");
     });
     it("4: Should not allow the artist to mint more than allocation", async function () {
       await expect(
         blueprint
           .connect(testArtist)
           .artistMint(0, testArtistArtistMintQuantity + 1)
-      ).to.be.revertedWith("can't mint quantity");
+      ).to.be.revertedWith("quantity >");
     });
     it("5: Should not allow other user to mint preSale", async function () {
       await expect(
         blueprint.connect(user1).artistMint(0, testArtistArtistMintQuantity)
-      ).to.be.revertedWith("user cannot mint presale");
+      ).to.be.revertedWith("unauthorized");
     });
     it("6: Should allow presale mint once sale started", async function () {
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -165,7 +167,7 @@ describe("Blueprint presale minting", function () {
         blueprint
           .connect(testArtist)
           .artistMint(0, testArtistArtistMintQuantity)
-      ).to.be.revertedWith("Must be presale or public sale");
+      ).to.be.revertedWith("not pre/public sale");
     });
   });
 });

--- a/test/interface-tests.js
+++ b/test/interface-tests.js
@@ -14,7 +14,7 @@ describe("Admin Blueprint Tests", function () {
     blueprint = await Blueprint.deploy();
     SplitMain = await ethers.getContractFactory("SplitMain");
     splitMain = await SplitMain.deploy();
-    blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+    blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
   });
   it("supports HasSecondarySaleFees interface", async function () {
     // This interfaceId is different than the _INTERFACE_ID_FEES that HasSecondarySaleFees registers with ERC165 but it matches its type(HasSecondarySaleFees).interfaceId which is what we really care about

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -92,21 +92,23 @@ describe("Merkleroot Tests", function () {
       blueprint = await Blueprint.deploy();
       SplitMain = await ethers.getContractFactory("SplitMain");
       splitMain = await SplitMain.deploy();
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          0,
+          [
+            tenThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            0
+          ],
           feesInput
         );
     });
@@ -123,16 +125,18 @@ describe("Merkleroot Tests", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           user3.address,
-          tenThousandPieces,
-          oneEth.div(2),
-          zeroAddress,
-          testHash,
-          testUri,
-          "0x0000000000000000000000000000000000000000000000000000000000000000",
-          0,
-          0,
-          0,
-          0,
+          [
+            tenThousandPieces,
+            oneEth.div(2),
+            zeroAddress,
+            testHash,
+            testUri,
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            0,
+            0,
+            0,
+            0
+          ],
           emptyFeeRecipients
         );
 

--- a/test/prepare-blueprint-tests.js
+++ b/test/prepare-blueprint-tests.js
@@ -71,23 +71,25 @@ describe("Prepare Blueprint", function () {
       blueprint = await Blueprint.deploy();
       SplitMain = await ethers.getContractFactory("SplitMain");
       splitMain = await SplitMain.deploy();
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
     });
     it("1: should prepare the blueprint", async function () {
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(0),
+          [
+            tenThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            BigNumber.from(0)
+          ],
           feesInput
         );
 
@@ -110,6 +112,29 @@ describe("Prepare Blueprint", function () {
           .connect(ContractOwner)
           .prepareBlueprint(
             testArtist.address,
+            [
+              tenThousandPieces,
+              oneEth,
+              zeroAddress,
+              testHash,
+              testUri,
+              this.merkleTree.getHexRoot(),
+              0,
+              0,
+              0,
+              BigNumber.from(1)
+            ],
+            emptyFeesInput
+          )
+      ).to.be.revertedWith("ended");
+    });
+    it("should allow timestamp to be a value in the future", async function () {
+      const saleEndTimestamp = BigNumber.from(Date.now()).div(1000).add(100000);
+      await blueprint
+        .connect(ContractOwner)
+        .prepareBlueprint(
+          testArtist.address,
+          [
             tenThousandPieces,
             oneEth,
             zeroAddress,
@@ -119,27 +144,8 @@ describe("Prepare Blueprint", function () {
             0,
             0,
             0,
-            BigNumber.from(1),
-            emptyFeesInput
-          )
-      ).to.be.revertedWith("Sale ended");
-    });
-    it("should allow timestamp to be a value in the future", async function () {
-      const saleEndTimestamp = BigNumber.from(Date.now()).div(1000).add(100000);
-      await blueprint
-        .connect(ContractOwner)
-        .prepareBlueprint(
-          testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(saleEndTimestamp),
+            BigNumber.from(saleEndTimestamp)
+          ],
           emptyFeesInput
         )
       let result = await blueprint.blueprints(0);
@@ -150,16 +156,18 @@ describe("Prepare Blueprint", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(0),
+          [
+            tenThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            BigNumber.from(0)
+          ],
           emptyFeesInput
         );
       let result = await blueprint.blueprints(0);
@@ -171,16 +179,18 @@ describe("Prepare Blueprint", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(0),
+          [
+            tenThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            BigNumber.from(0)
+          ],
           emptyFeesInput
         );
         
@@ -196,28 +206,30 @@ describe("Prepare Blueprint", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          tenThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(0),
+          [
+            tenThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            BigNumber.from(0)
+          ],
           emptyFeesInput
         );
       await expect(
         blueprint
           .connect(ContractOwner)
           .setFeeRecipients(0, { ...feesInput, primaryFeeBPS: mismatchBps })
-      ).to.be.revertedWith("bps over");
+      ).to.be.revertedWith("bps >");
     });
     it("should not allow sale for unprepared blueprint", async function () {
       await expect(
         blueprint.connect(ContractOwner).beginSale(0)
-      ).to.be.revertedWith("wrong sale state");
+      ).to.be.revertedWith("started");
     });
   });
 });

--- a/test/sales-tests.js
+++ b/test/sales-tests.js
@@ -78,21 +78,23 @@ describe("Blueprint Sales", function () {
       blueprint = await Blueprint.deploy();
       SplitMain = await ethers.getContractFactory("SplitMain");
       splitMain = await SplitMain.deploy();
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          oneThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          0,
+          [
+            oneThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            0
+          ],
           feesInput
         );
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -122,23 +124,25 @@ describe("Blueprint Sales", function () {
       expect(result.saleState.toString()).to.be.equal(sale_started);
       await expect(
         blueprint.connect(ContractOwner).unpauseSale(0)
-      ).to.be.revertedWith("Sale not paused");
+      ).to.be.revertedWith("!paused");
     });
     it("4: should not allow pausing of unstarted sale", async function () {
       await blueprint
         .connect(ContractOwner)
         .prepareBlueprint(
           user2.address,
-          oneThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash + "dsfdk",
-          testUri + "unpause_test",
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          0,
+          [
+            oneThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash + "dsfdk",
+            testUri + "unpause_test",
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            0
+          ],
           emptyFeesInput
         );
       await expect(
@@ -168,7 +172,7 @@ describe("Blueprint Sales", function () {
         blueprint
           .connect(user2)
           .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: blueprintValue })
-      ).to.be.revertedWith("purchase unavailable");
+      ).to.be.revertedWith("unavailable");
     });
     describe("B: Sale + purchase interactions", function () {
       it("1: should distribute fees", async function () {
@@ -195,7 +199,7 @@ describe("Blueprint Sales", function () {
           blueprint
             .connect(user2)
             .purchaseBlueprints(0, tenPieces, tenPieces, 10, [], { value: blueprintValue })
-        ).to.be.revertedWith("tokenAmount not zero");
+        ).to.be.revertedWith("tokenAmount != 0");
       });
       it("3: should not allow purchase of more than capacity", async function () {
         let fiveHundredPieces = BigNumber.from(oneThousandPieces).div(2);
@@ -224,16 +228,18 @@ describe("Blueprint Sales", function () {
           .connect(ContractOwner)
           .prepareBlueprint(
             testArtist.address,
-            oneThousandPieces,
-            oneEth,
-            zeroAddress,
-            testHash + "dsfdk",
-            testUri + "_test",
-            this.merkleTree.getHexRoot(),
-            0,
-            0,
-            0,
-            0,
+            [
+              oneThousandPieces,
+              oneEth,
+              zeroAddress,
+              testHash + "dsfdk",
+              testUri + "_test",
+              this.merkleTree.getHexRoot(),
+              0,
+              0,
+              0,
+              0
+            ],
             emptyFeesInput
           );
         await blueprint.connect(ContractOwner).beginSale(1);
@@ -289,7 +295,7 @@ describe("Blueprint Sales", function () {
       blueprint = await Blueprint.deploy();
       SplitMain = await ethers.getContractFactory("SplitMain");
       splitMain = await SplitMain.deploy();
-      blueprint.initialize("Async Blueprint", "ABP", ContractOwner.address, ContractOwner.address, splitMain.address);
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
       const latestBlock = await ethers.provider.getBlockNumber();
       const latestBlocktimestamp = (await ethers.provider.getBlock(latestBlock)).timestamp
       const nextBlockTimestamp = latestBlocktimestamp + 15
@@ -298,16 +304,18 @@ describe("Blueprint Sales", function () {
         .connect(ContractOwner)
         .prepareBlueprint(
           testArtist.address,
-          oneThousandPieces,
-          oneEth,
-          zeroAddress,
-          testHash,
-          testUri,
-          this.merkleTree.getHexRoot(),
-          0,
-          0,
-          0,
-          BigNumber.from(nextBlockTimestamp).add(10),
+          [
+            oneThousandPieces,
+            oneEth,
+            zeroAddress,
+            testHash,
+            testUri,
+            this.merkleTree.getHexRoot(),
+            0,
+            0,
+            0,
+            BigNumber.from(nextBlockTimestamp).add(10)
+          ],
           feesInput
         );
       await blueprint.connect(ContractOwner).beginSale(0);
@@ -325,7 +333,7 @@ describe("Blueprint Sales", function () {
       // Sale un-pausing should fail because the on-chain time has past the saleEndTimestamp
       await expect(
         blueprint.connect(ContractOwner).unpauseSale(0)
-      ).to.be.revertedWith("Sale ended");
+      ).to.be.revertedWith("ended");
     });
     it("2. Can't purchase blueprints from a sale with an expired timestamp", async function () {
       // Simulate a time delay by setting the timestamp of the next block far in the future
@@ -337,7 +345,7 @@ describe("Blueprint Sales", function () {
         blueprint
           .connect(user2)
           .purchaseBlueprints(0, tenPieces, tenPieces, 0, [], { value: BigNumber.from(tenPieces).mul(oneEth) })
-      ).to.be.revertedWith("purchase unavailable");
+      ).to.be.revertedWith("unavailable");
     });
     // TODO: consider a test that shows you can't pause a sale who's end timestamp has passed...but maybe we don't want this if we want the minter to be able
     //       to pause a sale then extend the timestamp/adjust settings and then unpause. Note tho this can be done using updateBlueprintSettings as is


### PR DESCRIPTION
We'd like to deploy two shared V12 contracts, one for music and one for visual art
    - So we'd want to move the V12 initialization out of the constructor, into its own function)
    - We'd have a new beacon contract shared by both V12 contracts
    - We'd want to emit blueprintId in the CreatorBlueprintsDeployed event so we can reliably track this on our server - take in as input, emit (don’t store anywhere) 
- have BlueprintV12 take in BlueprintPreparationConfig if possible (given the difference in inputs, may not be)  
- fix Taskudis' issue
- downsize contracts under size limit
- fix tests from modifications 
- fix scripts from modifications
