### PR TITLE
Patch: Prepare Blueprint Callable Multiple Times

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -38,7 +38,7 @@ contract BlueprintV12 is
     uint32 public defaultPlatformSecondarySalePercentage;
 
     /**
-     * @dev Token id of last ERC721 NFT minted
+     * @dev First token ID of the next Blueprint to be prepared
      */ 
     uint64 public latestErc721TokenIndex;
 
@@ -144,7 +144,7 @@ contract BlueprintV12 is
      * @param mintAmountArtist Amount of NFTs of Blueprint mintable by artist
      * @param mintAmountArtist Amount of NFTs of Blueprint mintable by platform 
      * @param capacity Number of NFTs in Blueprint 
-     * @param erc721TokenIndex Token ID of last NFT minted for Blueprint
+     * @param erc721TokenIndex First token ID of the next Blueprint to be prepared
      * @param maxPurchaseAmount Max number of NFTs purchasable in a single transaction
      * @param saleEndTimestamp Timestamp when the sale ends 
      * @param price Price per NFT in Blueprint

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -443,6 +443,7 @@ contract CreatorBlueprints is
     )   external 
         onlyRole(MINTER_ROLE)
     {
+        require(blueprint.saleState == SaleState.not_prepared, "already prepared");
         blueprint.capacity = config._capacity;
         blueprint.price = config._price;
 

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -27,7 +27,7 @@ contract CreatorBlueprints is
     uint32 public defaultPlatformPrimaryFeePercentage;    
 
     /**
-     * @dev Token id of last ERC721 NFT minted
+     * @dev First token ID of the next Blueprint to be prepared
      */ 
     uint64 public latestErc721TokenIndex;
 
@@ -101,7 +101,7 @@ contract CreatorBlueprints is
      * @param mintAmountArtist Amount of NFTs of Blueprint mintable by artist
      * @param mintAmountPlatform Amount of NFTs of Blueprint mintable by platform 
      * @param capacity Number of NFTs in Blueprint 
-     * @param erc721TokenIndex Token ID of last NFT minted for Blueprint
+     * @param erc721TokenIndex First token ID of the next Blueprint to be prepared
      * @param maxPurchaseAmount Max number of NFTs purchasable in a single transaction
      * @param saleEndTimestamp Timestamp when the sale ends 
      * @param price Price per NFT in Blueprint

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -73,7 +73,108 @@ describe("Merkleroot Tests", function () {
     );
   });
 
-  describe("A: Mint all whitelisted", function () {
+  describe("Without merkle root provided", function () {
+    let Blueprint;
+    let SplitMain;
+    let splitMain; 
+    let blueprint;
+    let creatorBlueprint;
+    let CreatorBlueprint;
+
+    let feesInput = {
+      primaryFeeBPS: [],
+      primaryFeeRecipients: [],
+      secondaryFeesInput: {
+        secondaryFeeRecipients: [],
+        secondaryFeeMPS: [],
+        totalRoyaltyCutBPS: 1000,
+        royaltyRecipient: zeroAddress
+      },
+      deploySplit: false
+    }
+    let creatorFeeAllocationBPS = 500;
+    
+    before(async function () {
+      [ContractOwner, user1, user2, user3, testArtist, testPlatform] =
+        await ethers.getSigners();
+
+      feesInput.primaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feesInput.primaryFeeBPS = [1000, 9000];
+      feesInput.secondaryFeesInput.secondaryFeeRecipients = [ContractOwner.address, testArtist.address];
+      feesInput.secondaryFeesInput.secondaryFeeMPS = [100000, 900000]    
+      
+      Blueprint = await ethers.getContractFactory("BlueprintV12");
+      blueprint = await Blueprint.deploy();
+      SplitMain = await ethers.getContractFactory("SplitMain");
+      splitMain = await SplitMain.deploy();
+
+      // initialize the per creator blueprint contract
+      CreatorBlueprint = await ethers.getContractFactory("CreatorBlueprints");
+      creatorBlueprint = await CreatorBlueprint.deploy();
+
+      // initialize the per creator blueprint contract
+      creatorBlueprint.initialize(["Steve's Blueprint", "ABP", "https://async.art/steve-metadata", testArtist.address], [ContractOwner.address, ContractOwner.address, ContractOwner.address], [splitMain.address, creatorFeeAllocationBPS], testPlatform.address);
+
+      // prepare a blueprint on the creator contract
+      await creatorBlueprint
+        .connect(ContractOwner)
+        .prepareBlueprint(
+          [
+            tenThousandPieces,
+            oneEth.div(2),
+            zeroAddress,
+            testHash,
+            testUri,
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            0,
+            0,
+            0,
+            0
+          ],
+          [[],[]]
+        );
+
+      blueprint.initialize("Async Blueprint", "ABP", [ContractOwner.address, ContractOwner.address, ContractOwner.address], splitMain.address);
+      await blueprint
+        .connect(ContractOwner)
+        .prepareBlueprint(
+          user3.address,
+          [
+            tenThousandPieces,
+            oneEth.div(2),
+            zeroAddress,
+            testHash,
+            testUri,
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            0,
+            0,
+            0,
+            0
+          ],
+          emptyFeeRecipients
+        );
+    });
+    it("BlueprintV12", async function() {
+      const proof = this.merkleTree.getHexProof(hashToken(user1.address, 10));
+      const blueprintValue = BigNumber.from(1).mul(oneEth).div(2);
+      await expect(
+        blueprint
+          .connect(user1)
+          .purchaseBlueprints(1, 1, 1, 0, proof, { value: blueprintValue })
+      ).to.be.revertedWith("e");
+    })
+    it("CreatorBlueprint", async function() {
+      const proof = this.merkleTree.getHexProof(hashToken(user1.address, 10));
+      const blueprintValue = BigNumber.from(1).mul(oneEth).div(2);
+      await expect(
+        creatorBlueprint
+          .connect(user1)
+          .purchaseBlueprints(1, 1, 0, proof, { value: blueprintValue })
+      ).to.be.revertedWith("e");
+    })
+  });
+
+  describe("with merkleroot defined", function () {
     let Blueprint;
     let SplitMain;
     let splitMain; 
@@ -170,62 +271,6 @@ describe("Merkleroot Tests", function () {
             .connect(user3)
             .purchaseBlueprints(1, 1, 0, proof, { value: oneEth })
         ).to.be.revertedWith("e");
-      })
-    });
-    describe("2: should not allow buyer when no merkle provided", function () {
-      it("BlueprintV12", async function() {
-        await blueprint
-        .connect(ContractOwner)
-        .prepareBlueprint(
-          user3.address,
-          [
-            tenThousandPieces,
-            oneEth.div(2),
-            zeroAddress,
-            testHash,
-            testUri,
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            0,
-            0,
-            0,
-            0
-          ],
-          emptyFeeRecipients
-        );
-        const proof = this.merkleTree.getHexProof(hashToken(user1.address, 10));
-        const blueprintValue = BigNumber.from(1).mul(oneEth).div(2);
-        await expect(
-          blueprint
-            .connect(user1)
-            .purchaseBlueprints(1, 1, 1, 0, proof, { value: blueprintValue })
-        ).to.be.revertedWith("e");
-      })
-      it("CreatorBlueprint", async function() {
-        await creatorBlueprint
-        .connect(ContractOwner)
-        .prepareBlueprint(
-          [
-            tenThousandPieces,
-            oneEth.div(2),
-            zeroAddress,
-            testHash,
-            testUri,
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            0,
-            0,
-            0,
-            0
-          ],
-          [[],[]]
-        );
-
-      const proof = this.merkleTree.getHexProof(hashToken(user1.address, 10));
-      const blueprintValue = BigNumber.from(1).mul(oneEth).div(2);
-      await expect(
-        creatorBlueprint
-          .connect(user1)
-          .purchaseBlueprints(1, 1, 0, proof, { value: blueprintValue })
-      ).to.be.revertedWith("e");
       })
     });
     describe("3: should revert when no proof provided", function () {


### PR DESCRIPTION
There was no guard against `prepareBlueprint` being called multiples times in the CreatorBlueprint.sol implementation (even though it should only be callable once since there is only one blueprint per CreatorBlueprint contract).