### PR TITLE
Merkle Root Immutability

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -91,7 +91,7 @@ contract BlueprintV12 is
      * @dev Tracks the number of whitelisted purchases by each address per blueprint
      * @dev This mapping is outside of the BP struct because it was added as part of an upgrade, and must be placed at the end of storage to avoid overwriting
      */
-    mapping(uint256 => mapping(address => uint256)) whitelistedPurchases;
+    mapping(uint256 => mapping(address => uint32)) whitelistedPurchases;
 
     /**
      * @dev Tracks state of Blueprint sale

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -80,7 +80,7 @@ contract CreatorBlueprints is
      * @dev A mapping from whitelisted addresses to amout of pre-sale blueprints purchased
      * @dev This is seperate from the Blueprint struct because it was introduced as part of an upgrade, and needs to be placed at the end of storage to avoid overwriting.
      */
-     mapping(address => uint256) whitelistedPurchases; 
+     mapping(address => uint32) whitelistedPurchases; 
 
     /**
      * @dev Tracks state of Blueprint sale

--- a/tasks/deploy/cbImplementation.js
+++ b/tasks/deploy/cbImplementation.js
@@ -9,3 +9,13 @@ task("deploy:cbImplementation", "Deploys CreatorBlueprints implementation")
 
     console.log(`CreatorBlueprints deployed to: ${creatorBlueprints.address}`) 
   });
+
+task("deploy:v12Implementation", "Deploys BlueprintV12 implementation")
+  .setAction(async (taskArgs, { ethers }) => {
+    const BlueprintV12 = await ethers.getContractFactory("BlueprintV12");
+    const blueprintV12 = await BlueprintV12.deploy();
+
+    await blueprintV12.deployed();
+
+    console.log(`BlueprintV12 deployed to: ${blueprintV12.address}`) 
+  });

--- a/test/merkleroot-tests.js
+++ b/test/merkleroot-tests.js
@@ -38,14 +38,6 @@ function hashToken(account, quantity) {
   );
 }
 
-function computeMerkleFromMapping(mapping) {
-  return new MerkleTree(
-    Object.entries(mapping).map((mapping) => hashToken(...mapping)),
-    keccak256,
-    { sortPairs: true }
-  );
-}
-
 describe("Merkleroot Tests", function () {
 
   // whitelist mapping
@@ -320,8 +312,6 @@ describe("Merkleroot Tests", function () {
         expect(result.capacity.toString()).to.be.equal(
           BigNumber.from(creatorCapacity).toString()
         );
-        mappingCreator[account] = (parseInt(quantity) - parseInt(quantityToPurchase)).toString()
-        this.creatorMerkleTree = computeMerkleFromMapping(mappingCreator)
         expect(result.merkleroot).to.be.equal(this.creatorMerkleTree.getHexRoot());
         //should end on the next index
         //this user owns 0 - 9, next user will own 10 - x
@@ -331,10 +321,10 @@ describe("Merkleroot Tests", function () {
         );
 
         // purchase second half of whitelisted amount
-        proof = this.creatorMerkleTree.getHexProof(hashToken(account, quantityToPurchase));
+        proof = this.creatorMerkleTree.getHexProof(hashToken(account, quantity));
         await creatorBlueprint
           .connect(buyer)
-          .purchaseBlueprints(quantityToPurchase, quantityToPurchase, 0, proof, { value: blueprintValue });
+          .purchaseBlueprints(quantityToPurchase, quantity, 0, proof, { value: blueprintValue });
 
         // assert on state changes of second purchase
         result = await creatorBlueprint.blueprint();
@@ -342,20 +332,16 @@ describe("Merkleroot Tests", function () {
         expect(result.capacity.toString()).to.be.equal(
           BigNumber.from(creatorCapacity).toString()
         );
-        mappingCreator[account] = "0"
-        this.creatorMerkleTree = computeMerkleFromMapping(mappingCreator)
         expect(result.merkleroot).to.be.equal(this.creatorMerkleTree.getHexRoot());
-        //should end on the next index
-        //this user owns 0 - 9, next user will own 10 - x
         creatorIndex = creatorIndex.add(BigNumber.from(quantityToPurchase));
         expect(result.erc721TokenIndex.toString()).to.be.equal(
           BigNumber.from(creatorIndex).toString()
         );
 
-        // Assert that we cannot buy anymore, not the best assertion,
-        proof = this.creatorMerkleTree.getHexProof(hashToken(account, "0"));
+        // Assert that we cannot buy anymore
+        proof = this.creatorMerkleTree.getHexProof(hashToken(account, quantity));
         await expect(
-          creatorBlueprint.connect(buyer).purchaseBlueprints(1, 1, 0, proof, {
+          creatorBlueprint.connect(buyer).purchaseBlueprints(1, quantity, 0, proof, {
             value: blueprintValue,
           })
         ).to.be.revertedWith("e");
@@ -383,8 +369,6 @@ describe("Merkleroot Tests", function () {
         expect(result.capacity.toString()).to.be.equal(
           BigNumber.from(capacity).toString()
         );
-        mapping[account] = (parseInt(quantity) - parseInt(quantityToPurchase)).toString()
-        this.merkleTree = computeMerkleFromMapping(mapping)
         expect(result.merkleroot).to.be.equal(this.merkleTree.getHexRoot());
         //should end on the next index
         //this user owns 0 - 9, next user will own 10 - x
@@ -394,10 +378,10 @@ describe("Merkleroot Tests", function () {
         );
 
         // purchase second half of whitelisted amount
-        proof = this.merkleTree.getHexProof(hashToken(account, quantityToPurchase));
+        proof = this.merkleTree.getHexProof(hashToken(account, quantity));
         await blueprint
           .connect(buyer)
-          .purchaseBlueprints(0, quantityToPurchase, quantityToPurchase, 0, proof, { value: blueprintValue });
+          .purchaseBlueprints(0, quantityToPurchase, quantity, 0, proof, { value: blueprintValue });
 
         // assert on state changes of second purchase
         result = await blueprint.blueprints(0);
@@ -405,20 +389,16 @@ describe("Merkleroot Tests", function () {
         expect(result.capacity.toString()).to.be.equal(
           BigNumber.from(capacity).toString()
         );
-        mapping[account] = "0"
-        this.merkleTree = computeMerkleFromMapping(mapping)
         expect(result.merkleroot).to.be.equal(this.merkleTree.getHexRoot());
-        //should end on the next index
-        //this user owns 0 - 9, next user will own 10 - x
         index = index.add(BigNumber.from(quantityToPurchase));
         expect(result.erc721TokenIndex.toString()).to.be.equal(
           BigNumber.from(index).toString()
         );
 
         // Assert that we cannot buy anymore, not the best assertion,
-        proof = this.merkleTree.getHexProof(hashToken(account, "0"));
+        proof = this.merkleTree.getHexProof(hashToken(account, quantity));
         await expect(
-          blueprint.connect(buyer).purchaseBlueprints(0, 1, 1, 0, proof, {
+          blueprint.connect(buyer).purchaseBlueprints(0, 1, quantity, 0, proof, {
             value: blueprintValue,
           })
         ).to.be.revertedWith("e");


### PR DESCRIPTION
Async wants to avoid a race condition on the merkleroot when there are multiple pre-sale purchases in the same block // short amount of time before their server can generate a new proof. As a result, we are pivoting to use the merkle tree as an efficient way to provide an upper bound on the number of BPs a whitelisted user can purchase. As the user purchases BPs the amount they have purchased will be incremented in a mapping from their address to a purchase quantity. Every time the user goes to make a purchase we validate that their current amount purchased must be less than or equal to their whitelisted value encoded in the merkletree.

This upgrade applies to both Blueprints V12 and CreatorBlueprints.