### PR TITLE
Minter Role Merkle Roll Update-ability

### DIFF
--- a/contracts/contracts/BlueprintV12.sol
+++ b/contracts/contracts/BlueprintV12.sol
@@ -527,6 +527,18 @@ contract BlueprintV12 is
     }
 
     /**
+     * @dev Update a blueprint's merkleroot
+     * @param _blueprintID Blueprint ID
+     * @param _newMerkleroot New merkleroot
+     */
+    function updateBlueprintMerkleroot (
+        uint256 _blueprintID,
+        bytes32 _newMerkleroot
+    ) external onlyRole(MINTER_ROLE) {
+        blueprints[_blueprintID].merkleroot = _newMerkleroot;
+    }
+
+    /**
      * @dev Update a blueprint's capacity
      * @param _blueprintID Blueprint ID 
      * @param _newCapacity New capacity

--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -478,6 +478,16 @@ contract CreatorBlueprints is
     }
 
     /**
+     * @dev Update a blueprint's merkleroot
+     * @param _newMerkleroot New merkleroot
+     */
+    function updateBlueprintMerkleroot (
+        bytes32 _newMerkleroot
+    ) external onlyRole(MINTER_ROLE) {
+        blueprint.merkleroot = _newMerkleroot;
+    }
+
+    /**
      * @dev Update a blueprint's capacity 
      * @param _newCapacity New capacity
      * @param _newLatestErc721TokenIndex Newly adjusted last ERC721 token id 

--- a/test/admin-tests.js
+++ b/test/admin-tests.js
@@ -114,6 +114,55 @@ describe("Blueprint Supports Interface Tests", function () {
       expect(platformAddress).to.be.equal(user2.address);
     });
   });
+  describe("2.a: should allow minter to update merkleroot", function () {
+    it("BlueprintV12", async function() {
+      await blueprint
+      .connect(ContractOwner)
+      .prepareBlueprint(
+        testArtist.address,
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
+        feesInput
+      );
+      let updatedMerkleroot = "0x0000000000000000000000000000000000000000000000000000000000000001";
+      await blueprint.connect(ContractOwner).updateBlueprintMerkleroot(0, updatedMerkleroot);
+      let result = await blueprint.blueprints(0);
+      await expect(result.merkleroot).to.be.equal(updatedMerkleroot);
+    });
+    it("CreatorBlueprints", async function() {
+      await creatorBlueprint
+      .connect(ContractOwner)
+      .prepareBlueprint(
+        [
+          tenThousandPieces,
+          oneEth,
+          zeroAddress,
+          testHash,
+          testUri,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          0,
+          0,
+          0,
+          0
+        ],
+        [[], []]
+      );
+      let updatedMerkleroot = "0x0000000000000000000000000000000000000000000000000000000000000001";
+      await creatorBlueprint.connect(ContractOwner).updateBlueprintMerkleroot(updatedMerkleroot);
+      let result = await creatorBlueprint.blueprint();
+      await expect(result.merkleroot).to.be.equal(updatedMerkleroot);
+    });
+  });
   describe("2.a: should allow for updating baseUri", function () {
     it("BlueprintV12", async function() {
       await blueprint


### PR DESCRIPTION
Added ability for MINTER to modify the merkleroot on a BP (both V12 and CBP).