### PR TITLE
[WIP] feat: introduce  Operator Filterer

### DIFF
--- a/contracts/contracts/CreatorBlueprints.sol
+++ b/contracts/contracts/CreatorBlueprints.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgrad
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { DefaultOperatorFiltererUpgradeable } from "./operatorFilterRegistry/upgradeable/DefaultOperatorFiltererUpgradeable.sol";
 
 /**
  * @dev Async Art Blueprint NFT contract with true creator provenance
@@ -15,6 +16,7 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
  */
 contract CreatorBlueprints is
     ERC721Upgradeable,
+    DefaultOperatorFiltererUpgradeable,
     HasSecondarySaleFees,
     AccessControlEnumerableUpgradeable,
     ReentrancyGuard
@@ -277,6 +279,7 @@ contract CreatorBlueprints is
         ERC721Upgradeable.__ERC721_init(creatorBlueprintsInput.name, creatorBlueprintsInput.symbol);
         HasSecondarySaleFees._initialize();
         AccessControlUpgradeable.__AccessControl_init();
+        __DefaultOperatorFilterer_init();
 
         _setupRole(DEFAULT_ADMIN_ROLE, creatorBlueprintsAdmins.platform);
         _setupRole(MINTER_ROLE, creatorBlueprintsAdmins.minter);
@@ -1136,5 +1139,33 @@ contract CreatorBlueprints is
             ERC721Upgradeable.supportsInterface(interfaceId) ||
             ERC165StorageUpgradeable.supportsInterface(interfaceId) ||
             AccessControlEnumerableUpgradeable.supportsInterface(interfaceId);
+    }
+
+    ////////////////////////////////////
+    /// Required function overide for Operator Filter Registry //////
+    ////////////////////////////////////
+
+    function setApprovalForAll(address operator, bool approved) public override onlyAllowedOperatorApproval(operator) {
+        super.setApprovalForAll(operator, approved);
+    }
+
+    function approve(address operator, uint256 tokenId) public override onlyAllowedOperatorApproval(operator) {
+        super.approve(operator, tokenId);
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data)
+        public
+        override
+        onlyAllowedOperator(from)
+    {
+        super.safeTransferFrom(from, to, tokenId, data);
     }
 }

--- a/contracts/contracts/operatorFilterRegistry/IOperatorFilterRegistry.sol
+++ b/contracts/contracts/operatorFilterRegistry/IOperatorFilterRegistry.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+interface IOperatorFilterRegistry {
+    function isOperatorAllowed(address registrant, address operator) external view returns (bool);
+    function register(address registrant) external;
+    function registerAndSubscribe(address registrant, address subscription) external;
+    function registerAndCopyEntries(address registrant, address registrantToCopy) external;
+    function unregister(address addr) external;
+    function updateOperator(address registrant, address operator, bool filtered) external;
+    function updateOperators(address registrant, address[] calldata operators, bool filtered) external;
+    function updateCodeHash(address registrant, bytes32 codehash, bool filtered) external;
+    function updateCodeHashes(address registrant, bytes32[] calldata codeHashes, bool filtered) external;
+    function subscribe(address registrant, address registrantToSubscribe) external;
+    function unsubscribe(address registrant, bool copyExistingEntries) external;
+    function subscriptionOf(address addr) external returns (address registrant);
+    function subscribers(address registrant) external returns (address[] memory);
+    function subscriberAt(address registrant, uint256 index) external returns (address);
+    function copyEntriesOf(address registrant, address registrantToCopy) external;
+    function isOperatorFiltered(address registrant, address operator) external returns (bool);
+    function isCodeHashOfFiltered(address registrant, address operatorWithCode) external returns (bool);
+    function isCodeHashFiltered(address registrant, bytes32 codeHash) external returns (bool);
+    function filteredOperators(address addr) external returns (address[] memory);
+    function filteredCodeHashes(address addr) external returns (bytes32[] memory);
+    function filteredOperatorAt(address registrant, uint256 index) external returns (address);
+    function filteredCodeHashAt(address registrant, uint256 index) external returns (bytes32);
+    function isRegistered(address addr) external returns (bool);
+    function codeHashOf(address addr) external returns (bytes32);
+}

--- a/contracts/contracts/operatorFilterRegistry/upgradeable/DefaultOperatorFiltererUpgradeable.sol
+++ b/contracts/contracts/operatorFilterRegistry/upgradeable/DefaultOperatorFiltererUpgradeable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import {OperatorFiltererUpgradeable} from "./OperatorFiltererUpgradeable.sol";
+
+abstract contract DefaultOperatorFiltererUpgradeable is OperatorFiltererUpgradeable {
+    address constant DEFAULT_SUBSCRIPTION = address(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6);
+
+    function __DefaultOperatorFilterer_init() internal onlyInitializing {
+        OperatorFiltererUpgradeable.__OperatorFilterer_init(DEFAULT_SUBSCRIPTION, true);
+    }
+}

--- a/contracts/contracts/operatorFilterRegistry/upgradeable/OperatorFiltererUpgradeable.sol
+++ b/contracts/contracts/operatorFilterRegistry/upgradeable/OperatorFiltererUpgradeable.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import "../IOperatorFilterRegistry.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+abstract contract OperatorFiltererUpgradeable is Initializable {
+    error OperatorNotAllowed(address operator);
+
+    IOperatorFilterRegistry constant operatorFilterRegistry =
+        IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E);
+
+    function __OperatorFilterer_init(address subscriptionOrRegistrantToCopy, bool subscribe)
+        internal
+        onlyInitializing
+    {
+        // If an inheriting token contract is deployed to a network without the registry deployed, the modifier
+        // will not revert, but the contract will need to be registered with the registry once it is deployed in
+        // order for the modifier to filter addresses.
+        if (address(operatorFilterRegistry).code.length > 0) {
+            if (!operatorFilterRegistry.isRegistered(address(this))) {
+                if (subscribe) {
+                    operatorFilterRegistry.registerAndSubscribe(address(this), subscriptionOrRegistrantToCopy);
+                } else {
+                    if (subscriptionOrRegistrantToCopy != address(0)) {
+                        operatorFilterRegistry.registerAndCopyEntries(address(this), subscriptionOrRegistrantToCopy);
+                    } else {
+                        operatorFilterRegistry.register(address(this));
+                    }
+                }
+            }
+        }
+    }
+
+    modifier onlyAllowedOperator(address from) virtual {
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (address(operatorFilterRegistry).code.length > 0) {
+            // Allow spending tokens from addresses with balance
+            // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+            // from an EOA.
+            if (from == msg.sender) {
+                _;
+                return;
+            }
+            if (!operatorFilterRegistry.isOperatorAllowed(address(this), msg.sender)) {
+                revert OperatorNotAllowed(msg.sender);
+            }
+        }
+        _;
+    }
+
+    modifier onlyAllowedOperatorApproval(address operator) virtual {
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (address(operatorFilterRegistry).code.length > 0) {
+            if (!operatorFilterRegistry.isOperatorAllowed(address(this), operator)) {
+                revert OperatorNotAllowed(operator);
+            }
+        }
+        _;
+    }
+}

--- a/contracts/contracts/operatorFilterRegistry/upgradeable/RevokableDefaultOperatorFiltererUpgradeable.sol
+++ b/contracts/contracts/operatorFilterRegistry/upgradeable/RevokableDefaultOperatorFiltererUpgradeable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import {RevokableOperatorFiltererUpgradeable} from "./RevokableOperatorFiltererUpgradeable.sol";
+
+abstract contract RevokableDefaultOperatorFiltererUpgradeable is RevokableOperatorFiltererUpgradeable {
+    address constant DEFAULT_SUBSCRIPTION = address(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6);
+
+    function __RevokableDefaultOperatorFilterer_init() internal onlyInitializing {
+        RevokableOperatorFiltererUpgradeable.__RevokableOperatorFilterer_init(DEFAULT_SUBSCRIPTION, true);
+    }
+}

--- a/contracts/contracts/operatorFilterRegistry/upgradeable/RevokableOperatorFiltererUpgradeable.sol
+++ b/contracts/contracts/operatorFilterRegistry/upgradeable/RevokableOperatorFiltererUpgradeable.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import {OperatorFiltererUpgradeable} from "./OperatorFiltererUpgradeable.sol";
+
+/**
+ * @title  RevokableOperatorFilterer
+ * @notice This contract is meant to allow contracts to permanently opt out of the OperatorFilterRegistry. The Registry
+ *         itself has an "unregister" function, but if the contract is ownable, the owner can re-register at any point.
+ *         As implemented, this abstract contract allows the contract owner to toggle the
+ *         isOperatorFilterRegistryRevoked flag in order to permanently bypass the OperatorFilterRegistry checks.
+ */
+abstract contract RevokableOperatorFiltererUpgradeable is OperatorFiltererUpgradeable {
+    error OnlyOwner();
+    error AlreadyRevoked();
+
+    bool private _isOperatorFilterRegistryRevoked;
+
+    function __RevokableOperatorFilterer_init(address subscriptionOrRegistrantToCopy, bool subscribe) internal {
+        OperatorFiltererUpgradeable.__OperatorFilterer_init(subscriptionOrRegistrantToCopy, subscribe);
+    }
+
+    modifier onlyAllowedOperator(address from) override {
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (!_isOperatorFilterRegistryRevoked && address(operatorFilterRegistry).code.length > 0) {
+            // Allow spending tokens from addresses with balance
+            // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+            // from an EOA.
+            if (from == msg.sender) {
+                _;
+                return;
+            }
+            if (!operatorFilterRegistry.isOperatorAllowed(address(this), msg.sender)) {
+                revert OperatorNotAllowed(msg.sender);
+            }
+        }
+        _;
+    }
+
+    modifier onlyAllowedOperatorApproval(address operator) override {
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (!_isOperatorFilterRegistryRevoked && address(operatorFilterRegistry).code.length > 0) {
+            if (!operatorFilterRegistry.isOperatorAllowed(address(this), operator)) {
+                revert OperatorNotAllowed(operator);
+            }
+        }
+        _;
+    }
+
+    /**
+     * @notice Disable the isOperatorFilterRegistryRevoked flag. OnlyOwner.
+     */
+    function revokeOperatorFilterRegistry() external {
+        if (msg.sender != owner()) {
+            revert OnlyOwner();
+        }
+        if (_isOperatorFilterRegistryRevoked) {
+            revert AlreadyRevoked();
+        }
+        _isOperatorFilterRegistryRevoked = true;
+    }
+
+    function isOperatorFilterRegistryRevoked() public view returns (bool) {
+        return _isOperatorFilterRegistryRevoked;
+    }
+
+    /**
+     * @dev assume the contract has an owner, but leave specific Ownable implementation up to inheriting contract
+     */
+    function owner() public view virtual returns (address);
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.7.0",
-    "@openzeppelin/contracts-upgradeable": "^4.3.2",
+    "@openzeppelin/contracts-upgradeable": "^4.8.0",
     "@openzeppelin/hardhat-upgrades": "^1.10.0",
     "@rari-capital/solmate": "^6.4.0",
     "chai": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz#92df481362e366c388fc02133cf793029c744cea"
-  integrity sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ==
+"@openzeppelin/contracts-upgradeable@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.0.tgz#26688982f46969018e3ed3199e72a07c8d114275"
+  integrity sha512-5GeFgqMiDlqGT8EdORadp1ntGF0qzWZLmEY7Wbp/yVhN7/B3NNzCxujuI77ktlyG81N3CUZP8cZe3ZAQ/cW10w==
 
 "@openzeppelin/contracts@^4.7.0":
   version "4.7.2"


### PR DESCRIPTION
- implement DefaultOperatorFiltererUpgradeable in CBP
- implement DefaultOperatorFiltererUpgradeable in v12
- bump up @openzeppelin/contracts-upgradeable dependancy

Followed this [Guide](https://github.com/ProjectOpenSea/operator-filter-registry)
Monday [item](https://async-art.monday.com/boards/2176855515/pulses/3552475851)

This is still a WIP, it hasn't been tested at all, please don't merge it ❗ 

# Considerations ❗ 
- If the newly added logic proofs that it's working correctly, BlueprintV12 contract exceeds the max contract size limitation (24kb). We have to think how to squeeze it in.

### TODOS:
- Deploy to testnet
- Test the new implementation. Try to sell a blueprint on the forbidden Marketplaces.
- Test the existing logic. Try to create and sell nfts on Async market.